### PR TITLE
feat(parser): make Flex scanner reentrant for concurrent parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Run Rust tests
         working-directory: bindings/rust
-        run: cargo test --lib --test integration -- --test-threads=1
+        run: cargo test --lib --test integration
 
   full-python-tests-linux:
     needs: [build-and-test, rust-check, python-check, windows-build]
@@ -312,7 +312,7 @@ jobs:
       - name: Test Rust bindings
         shell: bash
         working-directory: bindings/rust
-        run: cargo test --lib --test integration -- --test-threads=1
+        run: cargo test --lib --test integration
 
   # =============================================================================
   # Performance Tests - Main branch only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         if: matrix.arch != 'x86_64'
         working-directory: bindings/rust
         shell: bash
-        run: cargo test -- --test-threads=1
+        run: cargo test
 
       - name: Rename extension artifact
         run: cp build/${{ matrix.artifact }} build/${{ matrix.artifact-name }}

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ PARSER_SRCS = \
 
 # Generated sources
 SCANNER_SRC = $(BUILD_PARSER_DIR)/cypher_scanner.c
+SCANNER_HDR = $(BUILD_PARSER_DIR)/cypher_flex.h
 SCANNER_L = $(PARSER_DIR)/cypher_scanner.l
 GRAMMAR_SRC = $(BUILD_PARSER_DIR)/cypher_gram.tab.c
 GRAMMAR_HDR = $(BUILD_PARSER_DIR)/cypher_gram.tab.h
@@ -354,13 +355,18 @@ dirs:
 $(BUILD_PARSER_DIR)/%.o: $(PARSER_DIR)/%.c $(GRAMMAR_HDR) | dirs
 	$(CC) $(CFLAGS) -I$(BUILD_PARSER_DIR) -c $< -o $@
 
+# Scanner API needs Flex-generated header (reentrant API declarations)
+$(BUILD_PARSER_DIR)/cypher_scanner_api.o: $(SCANNER_HDR)
+
 # Parser objects (coverage build) - need build dir for generated headers
 $(BUILD_PARSER_DIR)/%.cov.o: $(PARSER_DIR)/%.c $(GRAMMAR_HDR) | dirs
 	$(CC) $(CFLAGS) $(COVERAGE_FLAGS) -I$(BUILD_PARSER_DIR) -c $< -o $@
 
-# Generate scanner from Flex specification
-$(SCANNER_SRC): $(SCANNER_L) | dirs
-	$(FLEX) -o $@ $<
+$(BUILD_PARSER_DIR)/cypher_scanner_api.cov.o: $(SCANNER_HDR)
+
+# Generate scanner from Flex specification (reentrant, with header for API)
+$(SCANNER_SRC) $(SCANNER_HDR): $(SCANNER_L) | dirs
+	$(FLEX) -o $(SCANNER_SRC) --header=$(SCANNER_HDR) $<
 
 # Generate parser from Bison grammar
 $(GRAMMAR_SRC) $(GRAMMAR_HDR): $(GRAMMAR_Y) | dirs
@@ -401,6 +407,8 @@ $(BUILD_EXECUTOR_DIR)/%.cov.o: $(EXECUTOR_DIR)/%.c | dirs
 # PIC object builds for shared library (uses vendored SQLite headers only - no EXTRA_INCLUDES)
 $(BUILD_PARSER_DIR)/%.pic.o: $(PARSER_DIR)/%.c $(GRAMMAR_HDR) | dirs
 	$(CC) $(EXTENSION_CFLAGS_BASE) $(EXTENSION_CFLAGS) -fPIC -I$(BUILD_PARSER_DIR) -c $< -o $@
+
+$(BUILD_PARSER_DIR)/cypher_scanner_api.pic.o: $(SCANNER_HDR)
 
 $(BUILD_PARSER_DIR)/cypher_scanner.pic.o: $(SCANNER_SRC) | dirs
 	$(CC) $(EXTENSION_CFLAGS_BASE) $(EXTENSION_CFLAGS) -fPIC -Wno-sign-compare -c $< -o $@
@@ -511,7 +519,7 @@ test-unit: $(TEST_RUNNER)
 
 test-rust: extension install-bundled
 	@echo "Running Rust binding tests..."
-	cd $(RUST_BINDINGS_DIR) && cargo test -- --test-threads=1
+	cd $(RUST_BINDINGS_DIR) && cargo test
 
 test-python: extension
 	@echo "Running Python binding tests..."

--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "graphqlite"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "rusqlite",
  "serde",

--- a/bindings/rust/tests/integration.rs
+++ b/bindings/rust/tests/integration.rs
@@ -19,6 +19,33 @@ fn test_open_memory() {
     assert!(conn.cypher("RETURN 1").is_ok());
 }
 
+/// Verifies concurrent parsing: multiple threads each run Cypher queries in parallel.
+/// The reentrant Flex scanner enables this without process-level serialization.
+#[test]
+fn test_concurrent_parsing() {
+    use std::thread;
+
+    let mut handles = vec![];
+
+    for i in 0..8 {
+        let handle = thread::spawn(move || {
+            let conn = test_connection();
+            for j in 0..20 {
+                let query = format!("RETURN {} as x, {} as y", i, j);
+                let results = conn.cypher(&query).expect("cypher should succeed");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].get::<i64>("x").unwrap(), i as i64);
+                assert_eq!(results[0].get::<i64>("y").unwrap(), j as i64);
+            }
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().expect("thread should not panic");
+    }
+}
+
 #[test]
 fn test_open_file() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/src/backend/parser/cypher_scanner.l
+++ b/src/backend/parser/cypher_scanner.l
@@ -2,6 +2,7 @@
 /*
  * Cypher Lexical Scanner for GraphQLite
  * Based on OpenCypher specification and AGE scanner
+ * Reentrant: no global state - enables concurrent parsing from multiple threads.
  */
 
 #include <stdio.h>
@@ -15,34 +16,26 @@
 #include "parser/cypher_keywords.h"
 #include "parser/cypher_tokens.h"
 
-/* Forward declaration */
-static void prepare_token(CypherTokenType type, const char *text);
-static void prepare_string_token(CypherTokenType type, const char *text, const char *value);
-static void prepare_integer_token(const char *text);
-static void prepare_decimal_token(const char *text);
-static void scanner_error(const char *message);
+/* Forward declarations - take state (yyextra) for reentrant operation */
+static void prepare_token(CypherScannerState *state, CypherTokenType type, const char *text);
+static void prepare_string_token(CypherScannerState *state, CypherTokenType type, const char *text, const char *value);
+static void prepare_integer_token(CypherScannerState *state, const char *text);
+static void prepare_decimal_token(CypherScannerState *state, const char *text);
+static void scanner_error(CypherScannerState *state, const char *message);
 static char* unescape_string(const char *escaped_str, int length);
 
-/* Global variables for current scanner state */
-CypherScannerState *current_scanner = NULL;
-static int current_line = 1;
-static int current_column = 1;
-
-/* Current token being built */
-static CypherToken current_token;
-
-/* Update location tracking */
+/* Update location tracking - yyextra is CypherScannerState* in reentrant mode */
 #define YY_USER_ACTION \
-    current_column += yyleng;
+    yyextra->current_column += yyleng;
 
-/* Token preparation instead of return */
+/* Token preparation macros - yyextra is the scanner state */
 #define RETURN_TOKEN(type) do { \
-    prepare_token(type, yytext); \
+    prepare_token(yyextra, type, yytext); \
     return (int)type; \
 } while(0)
 
 #define RETURN_STRING_TOKEN(type, value) do { \
-    prepare_string_token(type, yytext, value); \
+    prepare_string_token(yyextra, type, yytext, value); \
     return (int)type; \
 } while(0)
 
@@ -54,6 +47,10 @@ static CypherToken current_token;
 %option nounistd
 %option warn
 %option nodefault
+
+/* Reentrant: no global state - enables concurrent parsing */
+%option reentrant
+%option extra-type="CypherScannerState *"
 
 /* Remove unused functions to avoid warnings */
 %option noinput
@@ -106,8 +103,8 @@ operator    [+\-*/%^=!&|~]+
                     /* Count newlines for line tracking */
                     for (int i = 0; i < (int)yyleng; i++) {
                         if (yytext[i] == '\n') {
-                            current_line++;
-                            current_column = 1;
+                            yyextra->current_line++;
+                            yyextra->current_column = 1;
                         }
                     }
                     /* Skip whitespace - return next token */
@@ -131,8 +128,8 @@ operator    [+\-*/%^=!&|~]+
 
 <BLOCK_COMMENT>\n {
                     /* Count newlines in block comments */
-                    current_line++;
-                    current_column = 1;
+                    yyextra->current_line++;
+                    yyextra->current_column = 1;
                 }
 
 <BLOCK_COMMENT>.  {
@@ -147,20 +144,20 @@ operator    [+\-*/%^=!&|~]+
 {plus_eq}       { RETURN_TOKEN(CYPHER_TOKEN_PLUS_EQ); }
 {regex_match}   { RETURN_TOKEN(CYPHER_TOKEN_REGEX_MATCH); }
 
-{hexint}        { prepare_integer_token(yytext); return CYPHER_TOKEN_INTEGER; }
-{integer}       { prepare_integer_token(yytext); return CYPHER_TOKEN_INTEGER; }
-{decimal}       { prepare_decimal_token(yytext); return CYPHER_TOKEN_DECIMAL; }
+{hexint}        { prepare_integer_token(yyextra, yytext); return CYPHER_TOKEN_INTEGER; }
+{integer}       { prepare_integer_token(yyextra, yytext); return CYPHER_TOKEN_INTEGER; }
+{decimal}       { prepare_decimal_token(yyextra, yytext); return CYPHER_TOKEN_DECIMAL; }
 
 {string}        {
                     /* Remove quotes and handle escapes */
                     int len = yyleng - 2; /* Remove quotes */
                     char *unescaped = unescape_string(yytext + 1, len);
                     if (!unescaped) {
-                        scanner_error("Out of memory processing string literal");
+                        scanner_error(yyextra, "Out of memory processing string literal");
                         return CYPHER_TOKEN_EOF;
                     }
                     
-                    prepare_string_token(CYPHER_TOKEN_STRING, yytext, unescaped);
+                    prepare_string_token(yyextra, CYPHER_TOKEN_STRING, yytext, unescaped);
                     free(unescaped);
                     return CYPHER_TOKEN_STRING;
                 }
@@ -170,24 +167,24 @@ operator    [+\-*/%^=!&|~]+
                     int len = yyleng - 2;
                     char *unescaped = unescape_string(yytext + 1, len);
                     if (!unescaped) {
-                        scanner_error("Out of memory processing string literal");
+                        scanner_error(yyextra, "Out of memory processing string literal");
                         return CYPHER_TOKEN_EOF;
                     }
                     
-                    prepare_string_token(CYPHER_TOKEN_STRING, yytext, unescaped);
+                    prepare_string_token(yyextra, CYPHER_TOKEN_STRING, yytext, unescaped);
                     free(unescaped);
                     return CYPHER_TOKEN_STRING;
                 }
 
 \$[A-Za-z_][A-Za-z0-9_]* {
                     /* Named parameters: $name, $param1 */
-                    prepare_string_token(CYPHER_TOKEN_PARAMETER, yytext, yytext + 1);
+                    prepare_string_token(yyextra, CYPHER_TOKEN_PARAMETER, yytext, yytext + 1);
                     return CYPHER_TOKEN_PARAMETER;
                 }
 
 \$[0-9]+        {
                     /* Numeric parameters: $0, $1, $2, ... */
-                    prepare_string_token(CYPHER_TOKEN_PARAMETER, yytext, yytext + 1);
+                    prepare_string_token(yyextra, CYPHER_TOKEN_PARAMETER, yytext, yytext + 1);
                     return CYPHER_TOKEN_PARAMETER;
                 }
 
@@ -199,7 +196,7 @@ operator    [+\-*/%^=!&|~]+
                     if (value) {
                         strncpy(value, yytext + 2, len);
                         value[len] = '\0';
-                        prepare_string_token(CYPHER_TOKEN_PARAMETER, yytext, value);
+                        prepare_string_token(yyextra, CYPHER_TOKEN_PARAMETER, yytext, value);
                         free(value);
                     }
                     return CYPHER_TOKEN_PARAMETER;
@@ -210,14 +207,14 @@ operator    [+\-*/%^=!&|~]+
                     int len = yyleng - 2;
                     char *value = malloc(len + 1);
                     if (!value) {
-                        scanner_error("Out of memory");
+                        scanner_error(yyextra, "Out of memory");
                         return CYPHER_TOKEN_EOF;
                     }
                     
                     strncpy(value, yytext + 1, len);
                     value[len] = '\0';
                     
-                    prepare_string_token(CYPHER_TOKEN_BQIDENT, yytext, value);
+                    prepare_string_token(yyextra, CYPHER_TOKEN_BQIDENT, yytext, value);
                     free(value);
                     return CYPHER_TOKEN_BQIDENT;
                 }
@@ -227,104 +224,104 @@ operator    [+\-*/%^=!&|~]+
                     const CypherKeywordToken *kw = cypher_keyword_lookup_full(yytext);
                     if (kw && kw->category == RESERVED_KEYWORD) {
                         /* Only reserved keywords are treated as keywords */
-                        prepare_string_token(CYPHER_TOKEN_KEYWORD, yytext, yytext);
-                        current_token.token_id = kw->token;
+                        prepare_string_token(yyextra, CYPHER_TOKEN_KEYWORD, yytext, yytext);
+                        yyextra->current_token.token_id = kw->token;
                         return CYPHER_TOKEN_KEYWORD;
                     } else {
                         /* Unreserved keywords and non-keywords are identifiers */
-                        prepare_string_token(CYPHER_TOKEN_IDENTIFIER, yytext, yytext);
+                        prepare_string_token(yyextra, CYPHER_TOKEN_IDENTIFIER, yytext, yytext);
                         return CYPHER_TOKEN_IDENTIFIER;
                     }
                 }
 
-{operator}      { prepare_string_token(CYPHER_TOKEN_OPERATOR, yytext, yytext); return CYPHER_TOKEN_OPERATOR; }
+{operator}      { prepare_string_token(yyextra, CYPHER_TOKEN_OPERATOR, yytext, yytext); return CYPHER_TOKEN_OPERATOR; }
 
-:               { prepare_token(CYPHER_TOKEN_CHAR, yytext); return CYPHER_TOKEN_CHAR; }
-[(){}[\],;.<>]  { prepare_token(CYPHER_TOKEN_CHAR, yytext); return CYPHER_TOKEN_CHAR; }
+:               { prepare_token(yyextra, CYPHER_TOKEN_CHAR, yytext); return CYPHER_TOKEN_CHAR; }
+[(){}[\],;.<>]  { prepare_token(yyextra, CYPHER_TOKEN_CHAR, yytext); return CYPHER_TOKEN_CHAR; }
 
-<<EOF>>         { prepare_token(CYPHER_TOKEN_EOF, ""); return CYPHER_TOKEN_EOF; }
+<<EOF>>         { prepare_token(yyextra, CYPHER_TOKEN_EOF, ""); return CYPHER_TOKEN_EOF; }
 
 .               {
                     char msg[100];
                     snprintf(msg, sizeof(msg), "Unexpected character: '%c' (0x%02x)", 
                             yytext[0], (unsigned char)yytext[0]);
-                    scanner_error(msg);
-                    prepare_token(CYPHER_TOKEN_EOF, "");
+                    scanner_error(yyextra, msg);
+                    prepare_token(yyextra, CYPHER_TOKEN_EOF, "");
                     return CYPHER_TOKEN_EOF;
                 }
 
 %%
 
-/* Helper functions */
+/* Helper functions - all take state for reentrant operation */
 
-static void prepare_token(CypherTokenType type, const char *text)
+static void prepare_token(CypherScannerState *state, CypherTokenType type, const char *text)
 {
-    current_token.type = type;
-    current_token.token_id = 0;
-    current_token.line = current_line;
-    current_token.column = current_column - strlen(text);
-    current_token.text = strdup(text ? text : "");
+    state->current_token.type = type;
+    state->current_token.token_id = 0;
+    state->current_token.line = state->current_line;
+    state->current_token.column = state->current_column - (int)strlen(text);
+    state->current_token.text = strdup(text ? text : "");
     
     /* Initialize value based on type */
     switch (type) {
         case CYPHER_TOKEN_CHAR:
-            current_token.value.character = text[0];
+            state->current_token.value.character = text[0];
             break;
         default:
-            current_token.value.string = NULL;
+            state->current_token.value.string = NULL;
             break;
     }
 }
 
-static void prepare_string_token(CypherTokenType type, const char *text, const char *value)
+static void prepare_string_token(CypherScannerState *state, CypherTokenType type, const char *text, const char *value)
 {
-    prepare_token(type, text);
-    current_token.value.string = strdup(value ? value : "");
+    prepare_token(state, type, text);
+    state->current_token.value.string = strdup(value ? value : "");
 }
 
-static void prepare_integer_token(const char *text)
+static void prepare_integer_token(CypherScannerState *state, const char *text)
 {
-    prepare_token(CYPHER_TOKEN_INTEGER, text);
+    prepare_token(state, CYPHER_TOKEN_INTEGER, text);
     
     /* Parse integer with proper base detection */
     if (text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
         /* Hexadecimal */
-        current_token.value.integer = strtol(text, NULL, 16);
+        state->current_token.value.integer = strtol(text, NULL, 16);
     } else if (text[0] == '0' && strlen(text) > 1) {
         /* Octal */
-        current_token.value.integer = strtol(text, NULL, 8);
+        state->current_token.value.integer = strtol(text, NULL, 8);
     } else {
         /* Decimal */
-        current_token.value.integer = strtol(text, NULL, 10);
+        state->current_token.value.integer = strtol(text, NULL, 10);
     }
 }
 
-static void prepare_decimal_token(const char *text)
+static void prepare_decimal_token(CypherScannerState *state, const char *text)
 {
-    prepare_token(CYPHER_TOKEN_DECIMAL, text);
-    current_token.value.decimal = strtod(text, NULL);
+    prepare_token(state, CYPHER_TOKEN_DECIMAL, text);
+    state->current_token.value.decimal = strtod(text, NULL);
 }
 
-static void scanner_error(const char *message)
+static void scanner_error(CypherScannerState *state, const char *message)
 {
-    if (current_scanner) {
-        current_scanner->has_error = true;
-        current_scanner->last_error.line = current_line;
-        current_scanner->last_error.column = current_column;
+    if (state) {
+        state->has_error = true;
+        state->last_error.line = state->current_line;
+        state->last_error.column = state->current_column;
         
         /* Free previous error message if any */
-        if (current_scanner->last_error.message) {
-            free(current_scanner->last_error.message);
+        if (state->last_error.message) {
+            free(state->last_error.message);
         }
         
-        current_scanner->last_error.message = strdup(message);
+        state->last_error.message = strdup(message);
     }
 }
 
 /* Function to get the current prepared token */
-CypherToken cypher_scanner_get_current_token(void)
+CypherToken cypher_scanner_get_current_token(const CypherScannerState *state)
 {
-    return current_token;
+    return state ? state->current_token : (CypherToken){0};
 }
 
 /* Process escape sequences in string literals */

--- a/src/backend/parser/cypher_scanner_api.c
+++ b/src/backend/parser/cypher_scanner_api.c
@@ -1,6 +1,7 @@
 /*
  * Cypher Scanner API Implementation
- * High-level interface for the Flex-generated scanner
+ * High-level interface for the Flex-generated reentrant scanner
+ * Thread-safe: no global state - enables concurrent parsing
  */
 
 #include <stdio.h>
@@ -9,13 +10,8 @@
 
 #include "parser/cypher_scanner.h"
 
-/* External Flex functions (will be generated) */
-extern int yylex(void);
-extern void *yy_scan_string(const char *str);
-extern void yy_delete_buffer(void *buffer);
-
-/* External variables from scanner */
-extern CypherScannerState *current_scanner;
+/* Flex reentrant API - declarations from generated header */
+#include "cypher_flex.h"
 
 /* Scanner lifecycle functions */
 
@@ -25,18 +21,24 @@ CypherScannerState* cypher_scanner_create(void)
     if (!state) {
         return NULL;
     }
-    
-    /* Initialize error state */
+
     state->has_error = false;
     state->last_error.line = 0;
     state->last_error.column = 0;
     state->last_error.message = NULL;
-    state->scanner = NULL;
+    state->flex_scanner = NULL;
+    state->flex_buffer = NULL;
     state->input_string = NULL;
-    
-    /* Set global current_scanner for Flex callbacks */
-    current_scanner = state;
-    
+    state->current_line = 1;
+    state->current_column = 1;
+    state->current_token = (CypherToken){0};
+
+    /* Initialize Flex reentrant scanner with our state as extra data */
+    if (yylex_init_extra(state, (yyscan_t *)&state->flex_scanner) != 0) {
+        free(state);
+        return NULL;
+    }
+
     return state;
 }
 
@@ -45,22 +47,24 @@ void cypher_scanner_destroy(CypherScannerState *state)
     if (!state) {
         return;
     }
-    
-    /* Clean up buffer if any */
-    if (state->scanner) {
-        yy_delete_buffer(state->scanner);
+
+    /* Delete buffer if any */
+    if (state->flex_buffer) {
+        yy_delete_buffer((YY_BUFFER_STATE)state->flex_buffer, (yyscan_t)state->flex_scanner);
+        state->flex_buffer = NULL;
     }
-    
+
+    /* Destroy Flex scanner */
+    if (state->flex_scanner) {
+        yylex_destroy((yyscan_t)state->flex_scanner);
+        state->flex_scanner = NULL;
+    }
+
     /* Free error message if any */
     if (state->last_error.message) {
         free(state->last_error.message);
     }
-    
-    /* Clear global reference */
-    if (current_scanner == state) {
-        current_scanner = NULL;
-    }
-    
+
     free(state);
 }
 
@@ -71,12 +75,20 @@ int cypher_scanner_set_input_string(CypherScannerState *state, const char *input
     if (!state || !input) {
         return -1;
     }
-    
+
+    /* Delete previous buffer if any */
+    if (state->flex_buffer) {
+        yy_delete_buffer((YY_BUFFER_STATE)state->flex_buffer, (yyscan_t)state->flex_scanner);
+        state->flex_buffer = NULL;
+    }
+
     state->input_string = input;
-    
+    state->current_line = 1;
+    state->current_column = 1;
+
     /* Create Flex buffer for string input */
-    state->scanner = yy_scan_string(input);
-    
+    state->flex_buffer = yy_scan_string(input, (yyscan_t)state->flex_scanner);
+
     return 0;
 }
 
@@ -84,22 +96,19 @@ int cypher_scanner_set_input_string(CypherScannerState *state, const char *input
 CypherToken cypher_scanner_next_token(CypherScannerState *state)
 {
     CypherToken token = {0};
-    
+
     if (!state) {
         token.type = CYPHER_TOKEN_EOF;
         token.text = strdup("");
         return token;
     }
-    
-    /* Set current context for Flex callbacks */
-    current_scanner = state;
-    
-    /* Call Flex to get the next token */
-    yylex();
-    
-    /* Get the prepared token from the scanner */
-    token = cypher_scanner_get_current_token();
-    
+
+    /* Call Flex to get the next token - reentrant, no global state */
+    yylex((yyscan_t)state->flex_scanner);
+
+    /* Get the prepared token from our state */
+    token = cypher_scanner_get_current_token(state);
+
     return token;
 }
 
@@ -120,14 +129,14 @@ void cypher_scanner_clear_error(CypherScannerState *state)
     if (!state) {
         return;
     }
-    
+
     state->has_error = false;
-    
+
     if (state->last_error.message) {
         free(state->last_error.message);
         state->last_error.message = NULL;
     }
-    
+
     state->last_error.line = 0;
     state->last_error.column = 0;
 }
@@ -163,13 +172,13 @@ void cypher_token_free(CypherToken *token)
     if (!token) {
         return;
     }
-    
+
     /* Free text field */
     if (token->text) {
         free((void*)token->text);
         token->text = NULL;
     }
-    
+
     /* Free string value if applicable */
     if (token->type == CYPHER_TOKEN_STRING ||
         token->type == CYPHER_TOKEN_IDENTIFIER ||

--- a/src/include/parser/cypher_scanner.h
+++ b/src/include/parser/cypher_scanner.h
@@ -58,12 +58,17 @@ typedef struct CypherScannerError {
     char *message;
 } CypherScannerError;
 
-/* Scanner state */
+/* Scanner state - holds Flex reentrant handle and per-scan mutable state */
 typedef struct CypherScannerState {
-    cypher_scanner_t scanner;      /* Flex scanner handle */
+    void *flex_scanner;            /* Flex reentrant yyscan_t handle */
+    void *flex_buffer;             /* YY_BUFFER_STATE from yy_scan_string */
     const char *input_string;      /* Input string */
     CypherScannerError last_error; /* Last error encountered */
     bool has_error;                /* Error flag */
+    /* Per-scan state (no globals - enables concurrent parsing) */
+    int current_line;
+    int current_column;
+    CypherToken current_token;
 } CypherScannerState;
 
 /* Function prototypes */
@@ -88,6 +93,6 @@ const char* cypher_token_type_name(CypherTokenType type);
 void cypher_token_free(CypherToken *token);
 
 /* Internal function to get current token (used by API) */
-CypherToken cypher_scanner_get_current_token(void);
+CypherToken cypher_scanner_get_current_token(const CypherScannerState *state);
 
 #endif /* CYPHER_SCANNER_H */


### PR DESCRIPTION
### Summary

Replaces global mutable state in the Cypher lexer with per-scan state so multiple threads can parse Cypher queries concurrently without process-level serialization.

### Problem

The Flex scanner relied on global variables (`current_scanner`, `current_line`, `current_column`, `current_token`), which forced external serialization for thread safety. Rust tests were run with `--test-threads=1` to avoid races.

### Solution

- Add `%option reentrant` and `%option extra-type="CypherScannerState *"` to the Flex scanner
- Store per-scan state (line, column, token) in `CypherScannerState`
- Use the Flex reentrant API: `yylex_init_extra`, `yy_scan_string`, `yylex(scanner)`, `yylex_destroy`
- Generate `cypher_flex.h` for reentrant API declarations

### Changes

| File | Change |
|------|--------|
| `cypher_scanner.l` | Reentrant options, `yyextra` instead of globals |
| `cypher_scanner_api.c` | Reentrant API, remove `current_scanner` |
| `cypher_scanner.h` | Extend `CypherScannerState` with per-scan fields |
| Makefile | Flex `--header`, scanner API deps |
| CI workflows | Remove `--test-threads=1` |
| `integration.rs` | Add `test_concurrent_parsing` (8 threads × 20 queries) |

### Testing

- Extension builds successfully
- `gqlite` parses and executes Cypher queries
- `test_concurrent_parsing` validates concurrent parsing
- `cargo clippy --lib` passes

### Notes

- Requires Bison 3.x (e.g. `brew install bison` on macOS)
- Flex 2.5.22+ supports the reentrant option