### PR TITLE
Fix segfault on parameterized graph algorithm calls

### DIFF
--- a/src/backend/executor/graph_algo_traversal.c
+++ b/src/backend/executor/graph_algo_traversal.c
@@ -124,6 +124,13 @@ graph_algo_result* execute_bfs(sqlite3 *db, csr_graph *cached, const char *start
     result->error_message = NULL;
     result->json_result = NULL;
 
+    /* Guard against NULL start_id (e.g. unresolved parameter) */
+    if (!start_id) {
+        result->success = true;
+        result->json_result = strdup("[]");
+        return result;
+    }
+
     /* Use cached graph or load from SQLite */
     csr_graph *graph;
     bool should_free_graph = false;
@@ -280,6 +287,13 @@ graph_algo_result* execute_dfs(sqlite3 *db, csr_graph *cached, const char *start
     result->success = false;
     result->error_message = NULL;
     result->json_result = NULL;
+
+    /* Guard against NULL start_id (e.g. unresolved parameter) */
+    if (!start_id) {
+        result->success = true;
+        result->json_result = strdup("[]");
+        return result;
+    }
 
     /* Use cached graph or load from SQLite */
     csr_graph *graph;

--- a/src/backend/executor/graph_algorithms.c
+++ b/src/backend/executor/graph_algorithms.c
@@ -15,6 +15,7 @@
 
 #include "executor/graph_algorithms.h"
 #include "executor/graph_algo_internal.h"
+#include "executor/executor_internal.h"
 #include "parser/cypher_ast.h"
 
 /* Free CSR graph */
@@ -240,8 +241,41 @@ csr_graph* csr_graph_load(sqlite3 *db)
     return graph;
 }
 
+/*
+ * Resolve a function argument to a string value.
+ * Handles AST_NODE_LITERAL (string) and AST_NODE_PARAMETER (via params_json).
+ * Returns strdup'd string on success, NULL on failure.
+ */
+static char* resolve_string_arg(ast_node *node, const char *params_json)
+{
+    if (!node) return NULL;
+
+    if (node->type == AST_NODE_LITERAL) {
+        cypher_literal *lit = (cypher_literal *)node;
+        if (lit->literal_type == LITERAL_STRING && lit->value.string) {
+            return strdup(lit->value.string);
+        }
+        return NULL;
+    }
+
+    if (node->type == AST_NODE_PARAMETER) {
+        cypher_parameter *param = (cypher_parameter *)node;
+        if (!params_json || !param->name) return NULL;
+
+        property_type ptype;
+        char str_buf[256];
+        int rc = get_param_value(params_json, param->name, &ptype, str_buf, sizeof(str_buf));
+        if (rc == 0 && ptype == PROP_TYPE_TEXT) {
+            return strdup(str_buf);
+        }
+        return NULL;
+    }
+
+    return NULL;
+}
+
 /* Detect graph algorithm in RETURN clause */
-graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
+graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const char *params_json)
 {
     graph_algo_params params = {0};
     params.type = GRAPH_ALGO_NONE;
@@ -351,23 +385,11 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
         params.type = GRAPH_ALGO_DIJKSTRA;
 
         if (func->args && func->args->count >= 2) {
-            cypher_literal *src_lit = (cypher_literal *)func->args->items[0];
-            if (src_lit && src_lit->base.type == AST_NODE_LITERAL &&
-                src_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(src_lit->value.string);
-            }
-            cypher_literal *tgt_lit = (cypher_literal *)func->args->items[1];
-            if (tgt_lit && tgt_lit->base.type == AST_NODE_LITERAL &&
-                tgt_lit->literal_type == LITERAL_STRING) {
-                params.target_id = strdup(tgt_lit->value.string);
-            }
+            params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
+            params.target_id = resolve_string_arg((ast_node *)func->args->items[1], params_json);
         }
         if (func->args && func->args->count >= 3) {
-            cypher_literal *weight_lit = (cypher_literal *)func->args->items[2];
-            if (weight_lit && weight_lit->base.type == AST_NODE_LITERAL &&
-                weight_lit->literal_type == LITERAL_STRING) {
-                params.weight_prop = strdup(weight_lit->value.string);
-            }
+            params.weight_prop = resolve_string_arg((ast_node *)func->args->items[2], params_json);
         }
         return params;
     }
@@ -440,29 +462,13 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
 
         /* astar(source, target) or astar(source, target, lat_prop, lon_prop) */
         if (func->args && func->args->count >= 2) {
-            cypher_literal *src_lit = (cypher_literal *)func->args->items[0];
-            if (src_lit && src_lit->base.type == AST_NODE_LITERAL &&
-                src_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(src_lit->value.string);
-            }
-            cypher_literal *tgt_lit = (cypher_literal *)func->args->items[1];
-            if (tgt_lit && tgt_lit->base.type == AST_NODE_LITERAL &&
-                tgt_lit->literal_type == LITERAL_STRING) {
-                params.target_id = strdup(tgt_lit->value.string);
-            }
+            params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
+            params.target_id = resolve_string_arg((ast_node *)func->args->items[1], params_json);
         }
         /* Optional: lat and lon property names for heuristic */
         if (func->args && func->args->count >= 4) {
-            cypher_literal *lat_lit = (cypher_literal *)func->args->items[2];
-            if (lat_lit && lat_lit->base.type == AST_NODE_LITERAL &&
-                lat_lit->literal_type == LITERAL_STRING) {
-                params.lat_prop = strdup(lat_lit->value.string);
-            }
-            cypher_literal *lon_lit = (cypher_literal *)func->args->items[3];
-            if (lon_lit && lon_lit->base.type == AST_NODE_LITERAL &&
-                lon_lit->literal_type == LITERAL_STRING) {
-                params.lon_prop = strdup(lon_lit->value.string);
-            }
+            params.lat_prop = resolve_string_arg((ast_node *)func->args->items[2], params_json);
+            params.lon_prop = resolve_string_arg((ast_node *)func->args->items[3], params_json);
         }
         return params;
     }
@@ -474,11 +480,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
         params.max_depth = -1;  /* Unlimited by default */
 
         if (func->args && func->args->count >= 1) {
-            cypher_literal *start_lit = (cypher_literal *)func->args->items[0];
-            if (start_lit && start_lit->base.type == AST_NODE_LITERAL &&
-                start_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(start_lit->value.string);
-            }
+            params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
             cypher_literal *depth_lit = (cypher_literal *)func->args->items[1];
@@ -497,11 +499,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
         params.max_depth = -1;  /* Unlimited by default */
 
         if (func->args && func->args->count >= 1) {
-            cypher_literal *start_lit = (cypher_literal *)func->args->items[0];
-            if (start_lit && start_lit->base.type == AST_NODE_LITERAL &&
-                start_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(start_lit->value.string);
-            }
+            params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
             cypher_literal *depth_lit = (cypher_literal *)func->args->items[1];
@@ -521,17 +519,23 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
         params.source_id = NULL;
         params.target_id = NULL;
 
-        /* Check for specific pair: nodeSimilarity('node1', 'node2') */
+        /* Check for specific pair: nodeSimilarity('node1', 'node2') or with params */
         if (func->args && func->args->count >= 2) {
-            cypher_literal *node1_lit = (cypher_literal *)func->args->items[0];
-            cypher_literal *node2_lit = (cypher_literal *)func->args->items[1];
+            ast_node *arg0 = (ast_node *)func->args->items[0];
+            ast_node *arg1 = (ast_node *)func->args->items[1];
 
-            if (node1_lit && node1_lit->base.type == AST_NODE_LITERAL &&
-                node1_lit->literal_type == LITERAL_STRING &&
-                node2_lit && node2_lit->base.type == AST_NODE_LITERAL &&
-                node2_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(node1_lit->value.string);
-                params.target_id = strdup(node2_lit->value.string);
+            /* Try resolving as string args (literals or parameters) */
+            if (arg0 && (arg0->type == AST_NODE_LITERAL || arg0->type == AST_NODE_PARAMETER) &&
+                arg1 && (arg1->type == AST_NODE_LITERAL || arg1->type == AST_NODE_PARAMETER)) {
+                char *s0 = resolve_string_arg(arg0, params_json);
+                char *s1 = resolve_string_arg(arg1, params_json);
+                if (s0 && s1) {
+                    params.source_id = s0;
+                    params.target_id = s1;
+                } else {
+                    free(s0);
+                    free(s1);
+                }
             }
         }
         /* Check for threshold: nodeSimilarity(0.5) */
@@ -567,11 +571,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause)
 
         /* knn(node_id, k) */
         if (func->args && func->args->count >= 1) {
-            cypher_literal *node_lit = (cypher_literal *)func->args->items[0];
-            if (node_lit && node_lit->base.type == AST_NODE_LITERAL &&
-                node_lit->literal_type == LITERAL_STRING) {
-                params.source_id = strdup(node_lit->value.string);
-            }
+            params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
             cypher_literal *k_lit = (cypher_literal *)func->args->items[1];

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -911,7 +911,7 @@ static int handle_return_only(cypher_executor *executor, cypher_query *query,
     CYPHER_DEBUG("Executing standalone RETURN via pattern dispatch");
 
     /* Check for graph algorithm functions - execute in C for performance */
-    graph_algo_params algo_params = detect_graph_algorithm(ret);
+    graph_algo_params algo_params = detect_graph_algorithm(ret, executor->params_json);
     if (algo_params.type != GRAPH_ALGO_NONE) {
         graph_algo_result *algo_result = NULL;
 

--- a/src/include/executor/graph_algorithms.h
+++ b/src/include/executor/graph_algorithms.h
@@ -82,7 +82,7 @@ typedef struct {
 } graph_algo_params;
 
 /* Check if RETURN clause contains a graph algorithm call and extract parameters */
-graph_algo_params detect_graph_algorithm(cypher_return *return_clause);
+graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const char *params_json);
 
 /* Algorithm implementations
  * All algorithms accept an optional cached CSR graph parameter.

--- a/tests/functional/36_parameterized_algorithms.sql
+++ b/tests/functional/36_parameterized_algorithms.sql
@@ -1,0 +1,140 @@
+-- ========================================================================
+-- Test 36: Parameterized Graph Algorithms
+-- ========================================================================
+-- PURPOSE: Test parameter binding ($param) in graph algorithm functions
+-- COVERS:  bfs, dfs, dijkstra, astar, nodeSimilarity, knn with params
+-- BUG:     GitHub Issue #27 - segfault on parameterized traversals
+-- ========================================================================
+
+.load ./build/graphqlite
+
+SELECT '=== Test 36: Parameterized Graph Algorithms ===' as test_section;
+
+-- =======================================================================
+-- SETUP: Create a graph for traversal and algorithm testing
+-- =======================================================================
+SELECT '=== Setup: Creating test graph ===' as section;
+
+-- Create nodes with user_id properties for algorithm lookups
+SELECT cypher('CREATE (a:City {id: "A", name: "Alpha", lat: 0.0, lon: 0.0})') as setup;
+SELECT cypher('CREATE (b:City {id: "B", name: "Bravo", lat: 1.0, lon: 0.0})') as setup;
+SELECT cypher('CREATE (c:City {id: "C", name: "Charlie", lat: 1.0, lon: 1.0})') as setup;
+SELECT cypher('CREATE (d:City {id: "D", name: "Delta", lat: 0.0, lon: 1.0})') as setup;
+
+-- Create edges with weights: A->B(1), A->C(3), B->C(1), C->D(1)
+SELECT cypher('MATCH (a:City {id: "A"}), (b:City {id: "B"}) CREATE (a)-[:ROAD {weight: 1}]->(b)') as setup;
+SELECT cypher('MATCH (a:City {id: "A"}), (c:City {id: "C"}) CREATE (a)-[:ROAD {weight: 3}]->(c)') as setup;
+SELECT cypher('MATCH (b:City {id: "B"}), (c:City {id: "C"}) CREATE (b)-[:ROAD {weight: 1}]->(c)') as setup;
+SELECT cypher('MATCH (c:City {id: "C"}), (d:City {id: "D"}) CREATE (c)-[:ROAD {weight: 1}]->(d)') as setup;
+
+SELECT '=== Setup complete ===' as section;
+
+-- =======================================================================
+-- SECTION 1: BFS with parameters (GitHub Issue #27 - segfault)
+-- =======================================================================
+SELECT '=== Section 1: BFS with parameters ===' as section;
+
+SELECT 'Test 1.1 - BFS with literal (baseline):' as test_name;
+SELECT cypher('RETURN bfs("A")') as result;
+
+SELECT 'Test 1.2 - BFS with string parameter:' as test_name;
+SELECT cypher('RETURN bfs($start)', '{"start": "A"}') as result;
+
+SELECT 'Test 1.3 - BFS with parameter and max depth:' as test_name;
+SELECT cypher('RETURN bfs($start, 1)', '{"start": "A"}') as result;
+
+SELECT 'Test 1.4 - BFS parameter with different start node:' as test_name;
+SELECT cypher('RETURN bfs($node)', '{"node": "C"}') as result;
+
+-- =======================================================================
+-- SECTION 2: DFS with parameters
+-- =======================================================================
+SELECT '=== Section 2: DFS with parameters ===' as section;
+
+SELECT 'Test 2.1 - DFS with literal (baseline):' as test_name;
+SELECT cypher('RETURN dfs("A")') as result;
+
+SELECT 'Test 2.2 - DFS with string parameter:' as test_name;
+SELECT cypher('RETURN dfs($start)', '{"start": "A"}') as result;
+
+SELECT 'Test 2.3 - DFS with parameter and max depth:' as test_name;
+SELECT cypher('RETURN dfs($start, 1)', '{"start": "A"}') as result;
+
+SELECT 'Test 2.4 - DFS parameter with different start node:' as test_name;
+SELECT cypher('RETURN dfs($node)', '{"node": "C"}') as result;
+
+-- =======================================================================
+-- SECTION 3: Dijkstra with parameters
+-- =======================================================================
+SELECT '=== Section 3: Dijkstra with parameters ===' as section;
+
+SELECT 'Test 3.1 - Dijkstra with literals (baseline):' as test_name;
+SELECT cypher('RETURN dijkstra("A", "D")') as result;
+
+SELECT 'Test 3.2 - Dijkstra with source parameter:' as test_name;
+SELECT cypher('RETURN dijkstra($src, "D")', '{"src": "A"}') as result;
+
+SELECT 'Test 3.3 - Dijkstra with target parameter:' as test_name;
+SELECT cypher('RETURN dijkstra("A", $dst)', '{"dst": "D"}') as result;
+
+SELECT 'Test 3.4 - Dijkstra with both parameters:' as test_name;
+SELECT cypher('RETURN dijkstra($src, $dst)', '{"src": "A", "dst": "D"}') as result;
+
+-- =======================================================================
+-- SECTION 4: A* with parameters
+-- =======================================================================
+SELECT '=== Section 4: A* with parameters ===' as section;
+
+SELECT 'Test 4.1 - A* with literals (baseline):' as test_name;
+SELECT cypher('RETURN astar("A", "D")') as result;
+
+SELECT 'Test 4.2 - A* with source parameter:' as test_name;
+SELECT cypher('RETURN astar($src, "D")', '{"src": "A"}') as result;
+
+SELECT 'Test 4.3 - A* with both parameters:' as test_name;
+SELECT cypher('RETURN astar($src, $dst)', '{"src": "A", "dst": "D"}') as result;
+
+-- =======================================================================
+-- SECTION 5: Node Similarity with parameters
+-- =======================================================================
+SELECT '=== Section 5: Node Similarity with parameters ===' as section;
+
+SELECT 'Test 5.1 - nodeSimilarity with literals (baseline):' as test_name;
+SELECT cypher('RETURN nodeSimilarity("A", "B")') as result;
+
+SELECT 'Test 5.2 - nodeSimilarity with source parameter:' as test_name;
+SELECT cypher('RETURN nodeSimilarity($n1, "B")', '{"n1": "A"}') as result;
+
+SELECT 'Test 5.3 - nodeSimilarity with both parameters:' as test_name;
+SELECT cypher('RETURN nodeSimilarity($n1, $n2)', '{"n1": "A", "n2": "B"}') as result;
+
+-- =======================================================================
+-- SECTION 6: KNN with parameters
+-- =======================================================================
+SELECT '=== Section 6: KNN with parameters ===' as section;
+
+SELECT 'Test 6.1 - KNN with literal (baseline):' as test_name;
+SELECT cypher('RETURN knn("A", 3)') as result;
+
+SELECT 'Test 6.2 - KNN with node parameter:' as test_name;
+SELECT cypher('RETURN knn($node, 3)', '{"node": "A"}') as result;
+
+-- =======================================================================
+-- SECTION 7: Edge cases
+-- =======================================================================
+SELECT '=== Section 7: Edge cases ===' as section;
+
+SELECT 'Test 7.1 - BFS param with nonexistent node:' as test_name;
+SELECT cypher('RETURN bfs($start)', '{"start": "NONEXISTENT"}') as result;
+
+SELECT 'Test 7.2 - Dijkstra param with nonexistent source:' as test_name;
+SELECT cypher('RETURN dijkstra($src, "D")', '{"src": "NONEXISTENT"}') as result;
+
+-- =======================================================================
+-- TEARDOWN
+-- =======================================================================
+SELECT '=== Teardown: Cleaning up ===' as section;
+
+SELECT cypher('MATCH (n) DETACH DELETE n') as cleanup;
+
+SELECT '=== Test 36 Complete ===' as test_section;


### PR DESCRIPTION
## Summary

- Resolves segfault when graph algorithm functions (bfs, dfs, dijkstra, astar, nodeSimilarity, knn) are called with `$param` instead of literals on populated graphs
- `detect_graph_algorithm()` now resolves `AST_NODE_PARAMETER` nodes via existing `get_param_value()` infrastructure
- Added NULL guards in `execute_bfs()`/`execute_dfs()` as a safety net

Fixes #27

## Test plan

- [x] `angreal build extension` — builds clean
- [x] `tests/functional/36_parameterized_algorithms.sql` — all parameterized algo tests pass, no segfault
- [x] `angreal test functional` — existing functional tests pass
- [x] `angreal test unit` — all 770+ unit tests pass