### PR TITLE
Handle integer and double parameters passed to algorithms

### DIFF
--- a/src/backend/executor/graph_algorithms.c
+++ b/src/backend/executor/graph_algorithms.c
@@ -9,6 +9,7 @@
  * - graph_algo_centrality.c
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -274,6 +275,90 @@ static char* resolve_string_arg(ast_node *node, const char *params_json)
     return NULL;
 }
 
+/*
+ * Resolve a function argument to a int value.
+ * Handles AST_NODE_LITERAL (integer) and AST_NODE_PARAMETER (via params_json).
+ * Returns int on success, default_value on failure.
+ */
+static int resolve_int_arg(ast_node *node, const char *params_json, int default_value)
+{
+    if (!node) return default_value;
+
+    if (node->type == AST_NODE_LITERAL) {
+        cypher_literal *lit = (cypher_literal *)node;
+        if (lit && lit->base.type == AST_NODE_LITERAL && lit->literal_type == LITERAL_INTEGER) {
+            return (int) lit->value.integer;
+        }
+        return default_value;
+    }
+
+    if (node->type == AST_NODE_PARAMETER) {
+        cypher_parameter *param = (cypher_parameter *)node;
+        if (!params_json || !param->name) return default_value;
+
+        property_type ptype;
+        char str_buf[256];
+        int rc = get_param_value(params_json, param->name, &ptype, str_buf, sizeof(str_buf));
+        if (rc == 0 && ptype == PROP_TYPE_INTEGER) {
+			int64_t int_buf = *(int64_t*)str_buf;
+			if (int_buf-INT_MIN <= (int64_t)INT_MAX-INT_MIN) {
+				return (int)int_buf;
+			}
+        }
+
+		return default_value;
+    }
+
+    return default_value;
+}
+
+/*
+ * Resolve a function argument to a double value.
+ * Handles AST_NODE_LITERAL (double) and AST_NODE_PARAMETER (via params_json).
+ * Returns double on success, default_value on failure.
+ */
+static double resolve_double_arg(ast_node *node, const char *params_json, double default_value)
+{
+	if (!node) return default_value;
+
+    if (node->type == AST_NODE_LITERAL) {
+		cypher_literal *lit = (cypher_literal *)node;
+        if (lit && lit->base.type == AST_NODE_LITERAL) {
+            if (lit->literal_type == LITERAL_DECIMAL) {
+                return lit->value.decimal;
+            } else if (lit->literal_type == LITERAL_INTEGER) {
+                return (double)lit->value.integer;
+            }
+        }
+
+		return default_value;
+	}
+
+    if (node->type == AST_NODE_PARAMETER) {
+        cypher_parameter *param = (cypher_parameter *)node;
+        if (!params_json || !param->name) return default_value;
+
+        property_type ptype;
+        char str_buf[256];
+        int rc = get_param_value(params_json, param->name, &ptype, str_buf, sizeof(str_buf));
+
+		if (rc == 0 && ptype == PROP_TYPE_REAL) {
+			return *(double*)str_buf;
+        }
+
+        if (rc == 0 && ptype == PROP_TYPE_INTEGER) {
+			int64_t int_buf = *(int64_t*)str_buf;
+			if (int_buf-INT_MIN <= (int64_t)INT_MAX-INT_MIN) {
+				return (double)int_buf;
+			}
+        }
+
+		return default_value;
+    }
+
+    return default_value;
+}
+
 /* Detect graph algorithm in RETURN clause */
 graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const char *params_json)
 {
@@ -306,23 +391,12 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
         params.type = GRAPH_ALGO_PAGERANK;
 
         if (func->args && func->args->count >= 1) {
-            cypher_literal *damp_lit = (cypher_literal *)func->args->items[0];
-            if (damp_lit && damp_lit->base.type == AST_NODE_LITERAL) {
-                if (damp_lit->literal_type == LITERAL_DECIMAL) {
-                    params.damping = damp_lit->value.decimal;
-                } else if (damp_lit->literal_type == LITERAL_INTEGER) {
-                    params.damping = (double)damp_lit->value.integer;
-                }
-            }
+			params.damping = resolve_double_arg((ast_node *)func->args->items[0], params_json, params.damping);
         }
         if (func->args && func->args->count >= 2) {
-            cypher_literal *iter_lit = (cypher_literal *)func->args->items[1];
-            if (iter_lit && iter_lit->base.type == AST_NODE_LITERAL &&
-                iter_lit->literal_type == LITERAL_INTEGER) {
-                params.iterations = iter_lit->value.integer;
-                if (params.iterations < 1) params.iterations = 1;
-                if (params.iterations > 100) params.iterations = 100;
-            }
+			params.iterations = resolve_int_arg((ast_node *)func->args->items[1], params_json, params.iterations);
+            if (params.iterations < 1) params.iterations = 1;
+            if (params.iterations > 100) params.iterations = 100;
         }
         return params;
     }
@@ -333,32 +407,17 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
         params.top_k = 10;
 
         if (func->args && func->args->count >= 1) {
-            cypher_literal *k_lit = (cypher_literal *)func->args->items[0];
-            if (k_lit && k_lit->base.type == AST_NODE_LITERAL &&
-                k_lit->literal_type == LITERAL_INTEGER) {
-                params.top_k = k_lit->value.integer;
-                if (params.top_k < 1) params.top_k = 1;
-                if (params.top_k > 1000) params.top_k = 1000;
-            }
+			params.top_k = resolve_int_arg((ast_node *)func->args->items[0], params_json, params.top_k);
+            if (params.top_k < 1) params.top_k = 1;
+            if (params.top_k > 1000) params.top_k = 1000;
         }
         if (func->args && func->args->count >= 2) {
-            cypher_literal *damp_lit = (cypher_literal *)func->args->items[1];
-            if (damp_lit && damp_lit->base.type == AST_NODE_LITERAL) {
-                if (damp_lit->literal_type == LITERAL_DECIMAL) {
-                    params.damping = damp_lit->value.decimal;
-                } else if (damp_lit->literal_type == LITERAL_INTEGER) {
-                    params.damping = (double)damp_lit->value.integer;
-                }
-            }
+			params.damping = resolve_double_arg((ast_node *)func->args->items[1], params_json, params.damping);
         }
         if (func->args && func->args->count >= 3) {
-            cypher_literal *iter_lit = (cypher_literal *)func->args->items[2];
-            if (iter_lit && iter_lit->base.type == AST_NODE_LITERAL &&
-                iter_lit->literal_type == LITERAL_INTEGER) {
-                params.iterations = iter_lit->value.integer;
-                if (params.iterations < 1) params.iterations = 1;
-                if (params.iterations > 100) params.iterations = 100;
-            }
+			params.iterations = resolve_int_arg((ast_node *)func->args->items[2], params_json, params.iterations);
+            if (params.iterations < 1) params.iterations = 1;
+            if (params.iterations > 100) params.iterations = 100;
         }
         return params;
     }
@@ -369,13 +428,9 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
         params.iterations = 10;
 
         if (func->args && func->args->count >= 1) {
-            cypher_literal *iter_lit = (cypher_literal *)func->args->items[0];
-            if (iter_lit && iter_lit->base.type == AST_NODE_LITERAL &&
-                iter_lit->literal_type == LITERAL_INTEGER) {
-                params.iterations = iter_lit->value.integer;
-                if (params.iterations < 1) params.iterations = 1;
-                if (params.iterations > 100) params.iterations = 100;
-            }
+			params.iterations = resolve_int_arg((ast_node *)func->args->items[0], params_json, params.iterations);
+            if (params.iterations < 1) params.iterations = 1;
+            if (params.iterations > 100) params.iterations = 100;
         }
         return params;
     }
@@ -436,14 +491,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
 
         /* Optional resolution parameter */
         if (func->args && func->args->count >= 1) {
-            cypher_literal *res_lit = (cypher_literal *)func->args->items[0];
-            if (res_lit && res_lit->base.type == AST_NODE_LITERAL) {
-                if (res_lit->literal_type == LITERAL_DECIMAL) {
-                    params.resolution = res_lit->value.decimal;
-                } else if (res_lit->literal_type == LITERAL_INTEGER) {
-                    params.resolution = (double)res_lit->value.integer;
-                }
-            }
+            params.resolution = resolve_double_arg((ast_node *)func->args->items[0], params_json, params.resolution);
         }
         return params;
     }
@@ -483,11 +531,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
             params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
-            cypher_literal *depth_lit = (cypher_literal *)func->args->items[1];
-            if (depth_lit && depth_lit->base.type == AST_NODE_LITERAL &&
-                depth_lit->literal_type == LITERAL_INTEGER) {
-                params.max_depth = (int)depth_lit->value.integer;
-            }
+            params.max_depth = resolve_int_arg((ast_node *)func->args->items[1], params_json, -1);
         }
         return params;
     }
@@ -502,11 +546,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
             params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
-            cypher_literal *depth_lit = (cypher_literal *)func->args->items[1];
-            if (depth_lit && depth_lit->base.type == AST_NODE_LITERAL &&
-                depth_lit->literal_type == LITERAL_INTEGER) {
-                params.max_depth = (int)depth_lit->value.integer;
-            }
+            params.max_depth = resolve_int_arg((ast_node *)func->args->items[1], params_json, -1);
         }
         return params;
     }
@@ -540,24 +580,13 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
         }
         /* Check for threshold: nodeSimilarity(0.5) */
         else if (func->args && func->args->count >= 1) {
-            cypher_literal *thresh_lit = (cypher_literal *)func->args->items[0];
-            if (thresh_lit && thresh_lit->base.type == AST_NODE_LITERAL) {
-                if (thresh_lit->literal_type == LITERAL_DECIMAL) {
-                    params.threshold = thresh_lit->value.decimal;
-                } else if (thresh_lit->literal_type == LITERAL_INTEGER) {
-                    params.threshold = (double)thresh_lit->value.integer;
-                }
-            }
+            params.threshold = resolve_double_arg((ast_node *)func->args->items[0], params_json, params.threshold);
         }
 
         /* Check for top_k as last argument */
         if (func->args && func->args->count >= 2 && !params.source_id) {
             /* nodeSimilarity(threshold, top_k) */
-            cypher_literal *topk_lit = (cypher_literal *)func->args->items[1];
-            if (topk_lit && topk_lit->base.type == AST_NODE_LITERAL &&
-                topk_lit->literal_type == LITERAL_INTEGER) {
-                params.top_k = (int)topk_lit->value.integer;
-            }
+            params.top_k = resolve_int_arg((ast_node *)func->args->items[1], params_json, params.top_k);
         }
 
         return params;
@@ -574,11 +603,7 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
             params.source_id = resolve_string_arg((ast_node *)func->args->items[0], params_json);
         }
         if (func->args && func->args->count >= 2) {
-            cypher_literal *k_lit = (cypher_literal *)func->args->items[1];
-            if (k_lit && k_lit->base.type == AST_NODE_LITERAL &&
-                k_lit->literal_type == LITERAL_INTEGER) {
-                params.k = (int)k_lit->value.integer;
-            }
+            params.k = resolve_int_arg((ast_node *)func->args->items[1], params_json, params.k);
         }
 
         return params;
@@ -591,13 +616,9 @@ graph_algo_params detect_graph_algorithm(cypher_return *return_clause, const cha
 
         /* Optional iterations parameter */
         if (func->args && func->args->count >= 1) {
-            cypher_literal *iter_lit = (cypher_literal *)func->args->items[0];
-            if (iter_lit && iter_lit->base.type == AST_NODE_LITERAL &&
-                iter_lit->literal_type == LITERAL_INTEGER) {
-                params.iterations = (int)iter_lit->value.integer;
-                if (params.iterations < 1) params.iterations = 1;
-                if (params.iterations > 1000) params.iterations = 1000;
-            }
+            params.iterations = resolve_int_arg((ast_node *)func->args->items[0], params_json, params.iterations);
+            if (params.iterations < 1) params.iterations = 1;
+            if (params.iterations > 1000) params.iterations = 1000;
         }
         return params;
     }

--- a/tests/functional/36_parameterized_algorithms.sql
+++ b/tests/functional/36_parameterized_algorithms.sql
@@ -46,6 +46,9 @@ SELECT cypher('RETURN bfs($start, 1)', '{"start": "A"}') as result;
 SELECT 'Test 1.4 - BFS parameter with different start node:' as test_name;
 SELECT cypher('RETURN bfs($node)', '{"node": "C"}') as result;
 
+SELECT 'Test 1.5 - BFS with both parameters:' as test_name;
+SELECT cypher('RETURN bfs($start, $maxDepth)', '{"start": "A", "maxDepth": 1}') as result;
+
 -- =======================================================================
 -- SECTION 2: DFS with parameters
 -- =======================================================================
@@ -62,6 +65,9 @@ SELECT cypher('RETURN dfs($start, 1)', '{"start": "A"}') as result;
 
 SELECT 'Test 2.4 - DFS parameter with different start node:' as test_name;
 SELECT cypher('RETURN dfs($node)', '{"node": "C"}') as result;
+
+SELECT 'Test 2.5 - DFS with both parameters:' as test_name;
+SELECT cypher('RETURN dfs($start, $maxDepth)', '{"start": "A", "maxDepth": 1}') as result;
 
 -- =======================================================================
 -- SECTION 3: Dijkstra with parameters
@@ -99,14 +105,20 @@ SELECT cypher('RETURN astar($src, $dst)', '{"src": "A", "dst": "D"}') as result;
 -- =======================================================================
 SELECT '=== Section 5: Node Similarity with parameters ===' as section;
 
-SELECT 'Test 5.1 - nodeSimilarity with literals (baseline):' as test_name;
+SELECT 'Test 5.1 - nodeSimilarity with literal source and baseline (baseline):' as test_name;
 SELECT cypher('RETURN nodeSimilarity("A", "B")') as result;
 
 SELECT 'Test 5.2 - nodeSimilarity with source parameter:' as test_name;
 SELECT cypher('RETURN nodeSimilarity($n1, "B")', '{"n1": "A"}') as result;
 
-SELECT 'Test 5.3 - nodeSimilarity with both parameters:' as test_name;
+SELECT 'Test 5.3 - nodeSimilarity with source and target parameters:' as test_name;
 SELECT cypher('RETURN nodeSimilarity($n1, $n2)', '{"n1": "A", "n2": "B"}') as result;
+
+SELECT 'Test 5.4 - nodeSimilarity with literal threshold and top_k (baseline):' as test_name;
+SELECT cypher('RETURN nodeSimilarity(0.5, 3)') as result;
+
+SELECT 'Test 5.5 - nodeSimilarity with threshold and top_k parameters:' as test_name;
+SELECT cypher('RETURN nodeSimilarity($threshold, $topK)', '{"threshold": 0.5, "topK": 3}') as result;
 
 -- =======================================================================
 -- SECTION 6: KNN with parameters
@@ -119,15 +131,73 @@ SELECT cypher('RETURN knn("A", 3)') as result;
 SELECT 'Test 6.2 - KNN with node parameter:' as test_name;
 SELECT cypher('RETURN knn($node, 3)', '{"node": "A"}') as result;
 
--- =======================================================================
--- SECTION 7: Edge cases
--- =======================================================================
-SELECT '=== Section 7: Edge cases ===' as section;
+SELECT 'Test 6.2 - KNN with both parameters:' as test_name;
+SELECT cypher('RETURN knn($node, $k)', '{"node": "A", "k": 3}') as result;
 
-SELECT 'Test 7.1 - BFS param with nonexistent node:' as test_name;
+-- =======================================================================
+-- SECTION 7: pageRank with parameters
+-- =======================================================================
+SELECT '=== Section 7: pageRank with parameters ===' as section;
+
+SELECT 'Test 7.1 - pageRank with literal (baseline):' as test_name;
+SELECT cypher('RETURN pageRank(0.5, 101)') as result;
+
+SELECT 'Test 7.2 - pageRank with node parameters:' as test_name;
+SELECT cypher('RETURN pageRank($damping, $iterations)', '{"damping": 0.5, "iterations": 100}') as result;
+
+-- =======================================================================
+-- SECTION 8: topPageRank with parameters
+-- =======================================================================
+SELECT '=== Section 8: topPageRank with parameters ===' as section;
+
+SELECT 'Test 8.1 - topPageRank with literal (baseline):' as test_name;
+SELECT cypher('RETURN topPageRank(3, 0.5, 101)') as result;
+
+SELECT 'Test 8.2 - topPageRank with node parameters:' as test_name;
+SELECT cypher('RETURN topPageRank($top, $damping, $iterations)', '{"top": 3, "damping": 0.5, "iterations": 100}') as result;
+
+-- =======================================================================
+-- SECTION 9: labelPropagation with parameters
+-- =======================================================================
+SELECT '=== Section 9: labelPropagation with parameters ===' as section;
+
+SELECT 'Test 9.1 - labelPropagation with literal (baseline):' as test_name;
+SELECT cypher('RETURN labelPropagation(10)') as result;
+
+SELECT 'Test 9.2 - labelPropagation with node parameter:' as test_name;
+SELECT cypher('RETURN labelPropagation($iterations)', '{"iterations": 101}') as result;
+
+-- =======================================================================
+-- SECTION 10: louvain with parameters
+-- =======================================================================
+SELECT '=== Section 10: louvain with parameters ===' as section;
+
+SELECT 'Test 10.1 - louvain with literal (baseline):' as test_name;
+SELECT cypher('RETURN louvain(-0.5)') as result;
+
+SELECT 'Test 10.2 - louvain with node parameter:' as test_name;
+SELECT cypher('RETURN louvain($resolution)', '{"resolution": -0.5}') as result;
+
+-- =======================================================================
+-- SECTION 11: eigenvector with parameters
+-- =======================================================================
+SELECT '=== Section 11: eigenvectorCentrality with parameters ===' as section;
+
+SELECT 'Test 11.1 - eigenvectorCentrality with literal (baseline):' as test_name;
+SELECT cypher('RETURN eigenvectorCentrality(100)') as result;
+
+SELECT 'Test 11.2 - eigenvectorCentrality with node parameter:' as test_name;
+SELECT cypher('RETURN eigenvectorCentrality($iterations)', '{"iterations": 100}') as result;
+
+-- =======================================================================
+-- SECTION 12: Edge cases
+-- =======================================================================
+SELECT '=== Section 12: Edge cases ===' as section;
+
+SELECT 'Test 12.1 - BFS param with nonexistent node:' as test_name;
 SELECT cypher('RETURN bfs($start)', '{"start": "NONEXISTENT"}') as result;
 
-SELECT 'Test 7.2 - Dijkstra param with nonexistent source:' as test_name;
+SELECT 'Test 12.2 - Dijkstra param with nonexistent source:' as test_name;
 SELECT cypher('RETURN dijkstra($src, "D")', '{"src": "NONEXISTENT"}') as result;
 
 -- =======================================================================


### PR DESCRIPTION
This builds on #28, adding support for double and int parameters to the algorithm functions.

Warning: I am no C programmer! I went looking to see why they weren't working and then thought "that can't be too hard to fix". This may be all wrong.

I would have liked to throw errors when parameters are out of range rather than just setting to defaults (for instance, `params.iterations < 1`), but the existing code doesn't do that and I haven't figured out how to do it with SQLLite. Maybe something for another PR.