### PR TITLE
I-0044 Phase B continuation: T-0331/T-0332/T-0333 (+13 TCK)

### DIFF
--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,11 +275,11 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +65 TCK (3590 → 3655), 15 commits
+### 2026-05-26 — Session: +69 TCK (3590 → 3659), 16 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3655 / 3880 = 94.2% executable**.
+functional. Now **3659 / 3880 = 94.3% executable**.
 
 Cluster fixes this session (commit → area → delta):
 - Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds
@@ -312,6 +312,10 @@ Cluster fixes this session (commit → area → delta):
   input-scope var the WITH drops is now emitted INSIDE the CTE body
   (input tables still in FROM), not silently dropped. Narrow trigger
   (expr_refs_dropped_input_var); aggregating ORDER BY exprs excluded. +5
+- Graph7 [1] + Merge6 [3]/[7] + Merge7 [5] — dynamic property lookup
+  `n[expr]` / `n[$key]` on a node/edge via new `_gql_node_prop`/
+  `_gql_edge_prop` EAV-by-runtime-key UDFs. Graph7 [2]/[3] (CREATE+RETURN,
+  executor-evaluated) still open. +4
 - 2 correctness-only commits (+0 TCK): boolean projection through WITH
   renders as JSON boolean; undirected MERGE matches either orientation.
 

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,10 +275,12 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +79 TCK (3590 → 3669, 94.6%), 24 commits
-(+ Graph5 [2]/[5]: label/type predicate 3VL — r:T checks edge type, null→null,
-AST_NODE_LABEL_EXPR added to ast_yields_boolean. Grammar gap remains: `:A&B`
-conjunctive label expression, Graph5 [4].)
+### 2026-05-26 — Session: +82 TCK (3590 → 3672, 94.6%), 26 commits
+(+ Precedence2 [4]/[5]: unary minus on non-literal operands materialized as
+0 - expr — `-(3^2)` was dropping the negation. Precedence2 26/26.
++ Graph5 [2]/[5]: label/type predicate 3VL — r:T checks edge type, null→null,
+AST_NODE_LABEL_EXPR added to ast_yields_boolean. Grammar gap remains: conjunctive
+label expression :A&B, Graph5 [4].)
 
 ### 2026-05-26 — Session: +77 TCK (3590 → 3667), 22 commits
 

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,6 +275,13 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
+### 2026-05-26 — Post-temporal clusters: +4 (3680 → 3684, 94.9%)
+- Set1 [6]/[7]: CREATE+SET+RETURN now runs SET (the CREATE+RETURN dispatch
+  swallowed it); + `*_props_json` added to the CREATE+RETURN and
+  project_return_row_from_var_map property reads (list/map props were null).
+- Graph7 [2]/[3]: CREATE+RETURN now projects general expressions (subscript,
+  binary op, list/map) via new public executor_eval_value() wrapper.
+
 ### 2026-05-26 — Temporal cluster: +8 (3672 → 3680, 94.8%)
 Took the temporal cluster (biggest, ~40 fails). Landed the CONTAINED parts:
 - Temporal5 [4]: `_gql_temporal_field` offsetSeconds (= offsetMinutes*60).

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -274,3 +274,45 @@ Phase C is delegated to existing/future initiatives.
 
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
+
+### 2026-05-26 — Session: +57 TCK (3590 → 3647), 13 commits
+
+All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
+zero-regression via full-TCK pass-set diff + unit (944/944) +
+functional. Now **3647 / 3880 = 94.0% executable**.
+
+Cluster fixes this session (commit → area → delta):
+- Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds
+  the unwound entity (collect hydrates to JSON objects; bind alias to
+  `json_extract(value,'$.id')`). **B4.** +1
+- WithOrderBy1 [32] — WITH property projection missing `*_props_json`
+  (list/map props came back NULL). +2
+- Comparison2 [4] — element-wise list ordering in `_gql_order_cmp`;
+  maps/nodes/rels unorderable → null. **extends B2.** +4
+- Quantifier5–8 — unique `json_each` alias so nested quantifiers
+  (`single(x IN .. WHERE none(y IN x ..))`) don't shadow. **B3.** +24
+- list ORDER BY [9]/[10]/[31] (+ ReturnOrderBy1) — order-preserving
+  sort key for JSON lists in `_gql_order_key`. +7
+- Quantifier4 [10] — strict 3VL for `all()` (stale "Precedence1
+  conflict" comment was obsolete). **B3.** +5
+- Create6 [10]-[13] — edge properties in UNWIND+CREATE result path
+  (foreach-binding rel props, edge aggregates, edge prop projection).
+  **B4.** +4
+- Create6 [7]/[14] — aggregating WITH after CREATE (pure-aggregate
+  collapse over per-iteration maps). **B4 — Create6 now 14/14.** +2
+- Match6 [15]/[16]/[19]/[20] — full variable-length named-path
+  hydration (interleaved `elem_ids` CTE column + position-parity
+  build_path_from_ids). **This is Phase C / C3 — landed early.** +4
+- List5 [21]/[29]/[31]/[34] — `IN` 3VL for nested-null list elements
+  (gql_eq_json for containers, typed SQL `=` for scalars). +4
+- 2 correctness-only commits (+0 TCK): boolean projection through WITH
+  renders as JSON boolean; undirected MERGE matches either orientation.
+
+Remaining leads (root causes documented in agent memory files):
+- **Merge5 [12]/[13]** — combined synth re-match in handle_match_merge
+  drops inline node properties → undirected double-count rows.
+- **C3 residual**: Match6 [14] undirected varlen, [17] two-varlen
+  segments in one path.
+- **B5 (T-0332)** still active: Pattern2 [7]/[8]/[11] residual.
+- Temporal (C2, ~43), Comparison2 [3]/[5] (entities-in-lists, NaN),
+  Quantifier9/11 (rand/reverse/concat pipeline).

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -341,6 +341,28 @@ Investigated WithOrderBy2 [21]-[24] (DESC examples) and Merge5 [12]/[13]
 - With1 [4] / Match9 [9]: path variable forwarded through WITH ("no such
   column: p"); OPTIONAL varlen named path returns [] instead of null.
 
+#### Next-session priorities (clean wins are exhausted; these are the tail)
+Remaining 164 fails + 48 errors cluster into heavy interrelated areas:
+1. **Variable-length variants** (~12+): undirected (Match9 [1]/[3], Match6
+   [14], Pattern1 [10]/[17]/[18]), multi-segment / two-varlen-in-one-path
+   (Match6 [17]), mixed fixed+varlen chains returning empty (Match5 [25]/[26]/
+   [28], Match4 [4]/[5]). All touch generate_varlen_cte + the outer
+   endpoint/rel emission together. The elem_ids interleaved column (added this
+   session) is the foundation; the matching/dedupe is the remaining work.
+2. **Temporal** (~40: Temporal2/3/6/8/10) — week/quarter date construction,
+   timezone-name normalization, Duration type+arithmetic. Own initiative (C2).
+3. **NaN** (Comparison1 [8], Comparison2 [5]) — 0.0/0.0 is SQLite NULL; needs a
+   NaN sentinel threaded through division + comparison + ordering. Invasive.
+4. **Niche**: Merge5 [12]/[13] (combined-pattern property drop), Merge1 [13]
+   (path bound to MERGE), EXISTS{} subqueries (T-0139, unimplemented),
+   path-through-WITH (With1 [4]).
+Verification recipe for every change: `angreal test unit` + `angreal test
+functional` + full `angreal test tck`, then diff the pass-set against the prior
+run (script: print status+feature+scenario per record, comm -13/-23). SQL dump:
+temp `getenv("GQLITE_DUMP_SQL")` fopen in handle_generic_transform (generic
+path) or execute_match_return_query (MATCH+RETURN path). `angreal dev clean`
+after any function-signature change (incremental builds corrupt).
+
 Remaining leads (root causes documented in agent memory files):
 - **Merge5 [12]/[13]** — combined synth re-match in handle_match_merge
   drops inline node properties → undirected double-count rows.

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,6 +275,11 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
+### 2026-05-26 — Session: +79 TCK (3590 → 3669, 94.6%), 24 commits
+(+ Graph5 [2]/[5]: label/type predicate 3VL — r:T checks edge type, null→null,
+AST_NODE_LABEL_EXPR added to ast_yields_boolean. Grammar gap remains: `:A&B`
+conjunctive label expression, Graph5 [4].)
+
 ### 2026-05-26 — Session: +77 TCK (3590 → 3667), 22 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,13 +275,14 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +71 TCK (3590 → 3661), 17 commits
+### 2026-05-26 — Session: +74 TCK (3590 → 3664), 18 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3661 / 3880 = 94.4% executable**.
-(+ Graph6 [4]/[8]: `(list[1]).prop` via `_gql_dyn_prop` — node/rel-shaped
-JSON reads `$.properties.<key>`, plain maps read `$.<key>`.)
+functional. Now **3664 / 3880 = 94.4% executable**.
+(+ Graph6 [4]/[8]: `(list[1]).prop` via `_gql_dyn_prop`. + With1 [1]/[2] +
+WithSkipLimit2 [3]: RETURN * excludes synthetic `_gql_default_alias_` /
+`__unnamed_rel_` aliases — only user-named variables.)
 
 Cluster fixes this session (commit → area → delta):
 - Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,11 +275,11 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +60 TCK (3590 → 3650), 14 commits
+### 2026-05-26 — Session: +65 TCK (3590 → 3655), 15 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3650 / 3880 = 94.1% executable**.
+functional. Now **3655 / 3880 = 94.2% executable**.
 
 Cluster fixes this session (commit → area → delta):
 - Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds
@@ -308,6 +308,10 @@ Cluster fixes this session (commit → area → delta):
 - Aggregation2 [9]/[11]/[12] — Cypher-orderability `min()`/`max()` via
   custom `_gql_min`/`_gql_max` aggregates (order-key total order, type
   preserved via sqlite3_value_dup). Aggregation2 now 12/12. +3
+- WithOrderBy2 [21]-[24] + WithOrderBy4 [8] — ORDER BY referencing an
+  input-scope var the WITH drops is now emitted INSIDE the CTE body
+  (input tables still in FROM), not silently dropped. Narrow trigger
+  (expr_refs_dropped_input_var); aggregating ORDER BY exprs excluded. +5
 - 2 correctness-only commits (+0 TCK): boolean projection through WITH
   renders as JSON boolean; undirected MERGE matches either orientation.
 
@@ -317,15 +321,10 @@ Note: the order-key total order (object < list < text < bool < number
 
 Investigated WithOrderBy2 [21]-[24] (DESC examples) and Merge5 [12]/[13]
 — both NOT the orderability core; both are scope/transform-ordering bugs:
-- WithOrderBy2 [21]-[24]: `WITH a.name AS name ORDER BY a.name + 'C' DESC`
-  — the ORDER BY references input-scope `a`, which the WITH var-ctx reset
-  has discarded, so the ORDER BY is silently DROPPED from the SQL (verified:
-  generated `SELECT name FROM _with_0 LIMIT 2`, no ORDER BY). Fix needs
-  ORDER BY emitted inside the CTE body (input tables still in FROM) with
-  dual-scope resolution (input vars + projected aliases). Risky refactor of
-  a heavily-used path — deferred for a fresh session.
+- WithOrderBy2 [21]-[24] + WithOrderBy4 [8]: FIXED (commit 6bc2736) — ORDER BY
+  on a dropped input-scope var now emitted inside the CTE body.
 - Merge5 [12]/[13]: combined synth re-match in handle_match_merge drops
-  inline node properties → undirected double-count.
+  inline node properties → undirected double-count. (still open)
 
 Remaining leads (root causes documented in agent memory files):
 - **Merge5 [12]/[13]** — combined synth re-match in handle_match_merge

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,11 +275,13 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +69 TCK (3590 → 3659), 16 commits
+### 2026-05-26 — Session: +71 TCK (3590 → 3661), 17 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3659 / 3880 = 94.3% executable**.
+functional. Now **3661 / 3880 = 94.4% executable**.
+(+ Graph6 [4]/[8]: `(list[1]).prop` via `_gql_dyn_prop` — node/rel-shaped
+JSON reads `$.properties.<key>`, plain maps read `$.<key>`.)
 
 Cluster fixes this session (commit → area → delta):
 - Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,6 +275,20 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
+### 2026-05-27 — Remaining deep tail decomposed into Phase-C initiatives
+
+The deep remainder (Phase C) is now broken out into three sibling initiatives
+so I-0044 can close at the conformance-push level. Each carries the per-cluster
+root causes from this push and reuses the cores landed here:
+- [[GQLITE-I-0046]] Temporal & Duration Type Completeness (C2) — ~30 scenarios.
+- [[GQLITE-I-0047]] Pattern & Path Matching Completeness (B1 + C3) — ~15-18.
+- [[GQLITE-I-0048]] Collection & Comparability Semantics — ~15-20.
+New-language features (EXISTS{}, label disjunction) remain in [[GQLITE-I-0045]];
+pattern-comprehension lowering residual stays in task GQLITE-T-0332.
+I-0044 hit 94.9% executable (3684/3880, +135 from the 91.5% v0.5.0 baseline /
++94 this session) — its Phase-A/B goals (≥+40) are met; the 95% target's last
+points live in the C-initiatives above.
+
 ### 2026-05-26 — Post-temporal clusters: +4 (3680 → 3684, 94.9%)
 - Set1 [6]/[7]: CREATE+SET+RETURN now runs SET (the CREATE+RETURN dispatch
   swallowed it); + `*_props_json` added to the CREATE+RETURN and

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,11 +275,13 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +74 TCK (3590 → 3664), 18 commits
+### 2026-05-26 — Session: +75 TCK (3590 → 3665), 20 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3664 / 3880 = 94.4% executable**.
+functional. Now **3665 / 3880 = 94.5% executable**.
+(+ Path2 [3]: relationships()/nodes() on a null OPTIONAL path return null,
+not [null]. Reverted an undirected-varlen attempt that regressed Delete4 [2].)
 (+ Graph6 [4]/[8]: `(list[1]).prop` via `_gql_dyn_prop`. + With1 [1]/[2] +
 WithSkipLimit2 [3]: RETURN * excludes synthetic `_gql_default_alias_` /
 `__unnamed_rel_` aliases — only user-named variables.)

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,13 +275,17 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +75 TCK (3590 → 3665), 20 commits
+### 2026-05-26 — Session: +77 TCK (3590 → 3667), 22 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3665 / 3880 = 94.5% executable**.
-(+ Path2 [3]: relationships()/nodes() on a null OPTIONAL path return null,
-not [null]. Reverted an undirected-varlen attempt that regressed Delete4 [2].)
+functional. Now **3667 / 3880 = 94.5% executable**.
+(+ Path2 [3]: relationships()/nodes() on null OPTIONAL path → null.
++ Path2 [1]/[2]: relationships() on a variable-length path — build the
+rel-object list from the CTE's elem_ids (edges at odd positions). Path2 3/3.
+Also fixed the RETURN <varlen rel var> projection to use elem_ids not the
+buggy node-only path_ids. Reverted an undirected-varlen CTE attempt that
+regressed Delete4 [2].)
 (+ Graph6 [4]/[8]: `(list[1]).prop` via `_gql_dyn_prop`. + With1 [1]/[2] +
 WithSkipLimit2 [3]: RETURN * excludes synthetic `_gql_default_alias_` /
 `__unnamed_rel_` aliases — only user-named variables.)

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,11 +275,11 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
-### 2026-05-26 — Session: +57 TCK (3590 → 3647), 13 commits
+### 2026-05-26 — Session: +60 TCK (3590 → 3650), 14 commits
 
 All on PR branch `i0044-phase-b2-cross-type-cmp`, each verified
 zero-regression via full-TCK pass-set diff + unit (944/944) +
-functional. Now **3647 / 3880 = 94.0% executable**.
+functional. Now **3650 / 3880 = 94.1% executable**.
 
 Cluster fixes this session (commit → area → delta):
 - Unwind1 [12] — UNWIND over `collect(node)` → trailing MATCH binds
@@ -305,8 +305,27 @@ Cluster fixes this session (commit → area → delta):
   build_path_from_ids). **This is Phase C / C3 — landed early.** +4
 - List5 [21]/[29]/[31]/[34] — `IN` 3VL for nested-null list elements
   (gql_eq_json for containers, typed SQL `=` for scalars). +4
+- Aggregation2 [9]/[11]/[12] — Cypher-orderability `min()`/`max()` via
+  custom `_gql_min`/`_gql_max` aggregates (order-key total order, type
+  preserved via sqlite3_value_dup). Aggregation2 now 12/12. +3
 - 2 correctness-only commits (+0 TCK): boolean projection through WITH
   renders as JSON boolean; undirected MERGE matches either orientation.
+
+Note: the order-key total order (object < list < text < bool < number
+< null) now powers ORDER BY (_gql_order_key), list `=`/`IN`
+(gql_eq_json), and `min()`/`max()` — a reusable orderability core.
+
+Investigated WithOrderBy2 [21]-[24] (DESC examples) and Merge5 [12]/[13]
+— both NOT the orderability core; both are scope/transform-ordering bugs:
+- WithOrderBy2 [21]-[24]: `WITH a.name AS name ORDER BY a.name + 'C' DESC`
+  — the ORDER BY references input-scope `a`, which the WITH var-ctx reset
+  has discarded, so the ORDER BY is silently DROPPED from the SQL (verified:
+  generated `SELECT name FROM _with_0 LIMIT 2`, no ORDER BY). Fix needs
+  ORDER BY emitted inside the CTE body (input tables still in FROM) with
+  dual-scope resolution (input vars + projected aliases). Risky refactor of
+  a heavily-used path — deferred for a fresh session.
+- Merge5 [12]/[13]: combined synth re-match in handle_match_merge drops
+  inline node properties → undirected double-count.
 
 Remaining leads (root causes documented in agent memory files):
 - **Merge5 [12]/[13]** — combined synth re-match in handle_match_merge

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -275,6 +275,29 @@ Phase C is delegated to existing/future initiatives.
 Filed at v0.5.0 baseline (3549 / 3880 = 91.5%). Discovery phase
 — awaiting human review before decomposing into tasks.
 
+### 2026-05-26 — Temporal cluster: +8 (3672 → 3680, 94.8%)
+Took the temporal cluster (biggest, ~40 fails). Landed the CONTAINED parts:
+- Temporal5 [4]: `_gql_temporal_field` offsetSeconds (= offsetMinutes*60).
+- Temporal5 [7]: duration component accessors — new `_gql_duration_field`
+  computes years/quarters/weeks/hours/...Of... from normalized
+  {months,days,seconds,nanosecondsOfSecond}; routed via the `_iso8601` key.
+- Temporal6 [6] (all 5): ISO duration round-trip — the parser carried sub-day
+  seconds into days (PT-1.999S→-1d23h59m58s) and mis-rounded negative
+  fractional seconds (+0.5 const). Delegate to emit_duration_json + round
+  half-away-from-zero. Temporal6 17/17.
+- Temporal3 [3] ex16: time value drops resolved named-zone bracket.
+Temporal REMAINING (deep — genuine Phase C / own initiative):
+- Duration fractional composition + multiply/divide + between + DST
+  (Temporal8 [2]-[7] example-3 fractional, Temporal10) — needs the exact
+  Neo4j fractional-cascade & carry algorithm. Division reverse-engineering
+  attempted, not cracked (months→days→seconds carry with avg-month days).
+- Calendar week/quarter date construction (Temporal3 [1]).
+- Named-tz resolution at `time({timezone:'Name'})` construction (Temporal3 [3]
+  17/19): construction keeps `[Name]` with no offset; needs named_tz_offset
+  exposed as a UDF and called from the time() construction in
+  transform_func_temporal.c (~line 282-296). `_gql_time_compose` then inherits it.
+- Temporal2 parsing edge cases.
+
 ### 2026-05-26 — Session: +82 TCK (3590 → 3672, 94.6%), 26 commits
 (+ Precedence2 [4]/[5]: unary minus on non-literal operands materialized as
 0 - expr — `-(3^2)` was dropping the negation. Precedence2 26/26.

--- a/.metis/initiatives/GQLITE-I-0044/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0044/initiative.md
@@ -332,6 +332,14 @@ Investigated WithOrderBy2 [21]-[24] (DESC examples) and Merge5 [12]/[13]
   on a dropped input-scope var now emitted inside the CTE body.
 - Merge5 [12]/[13]: combined synth re-match in handle_match_merge drops
   inline node properties → undirected double-count. (still open)
+- Undirected variable-length (Match9 [1]/[3], Match6 [14], Pattern1 [10]/[17]/
+  [18], Delete4): tried making generate_varlen_cte bidirectional (both edge
+  orientations) — gets the row COUNT closer but the outer undirected endpoint
+  matching then double-counts (regressed Delete4 [2]); reverted. The CTE
+  bidirectional traversal AND the outer endpoint-pattern emission must be made
+  consistent together (dedupe one against the other). Not a CTE-only fix.
+- With1 [4] / Match9 [9]: path variable forwarded through WITH ("no such
+  column: p"); OPTIONAL varlen named path returns [] instead of null.
 
 Remaining leads (root causes documented in agent memory files):
 - **Merge5 [12]/[13]** — combined synth re-match in handle_match_merge

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0331.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0331.md
@@ -4,14 +4,14 @@ level: task
 title: "B2: Cross-type comparison null semantics — 1 < 'a' returns null per Cypher spec"
 short_code: "GQLITE-T-0331"
 created_at: 2026-05-23T18:17:41.906377+00:00
-updated_at: 2026-05-23T18:17:41.906377+00:00
+updated_at: 2026-05-24T14:00:33.352609+00:00
 parent: GQLITE-I-0044
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -26,9 +26,11 @@ initiative_id: GQLITE-I-0044
 
 [[GQLITE-I-0044]]
 
-## Objective **[REQUIRED]**
+## Objective
 
-{Clear statement of what this task accomplishes}
+Per the Cypher spec, ordered comparisons (`<`, `<=`, `>`, `>=`) between values of incompatible types (e.g. number vs string, number vs boolean, string vs boolean) must return `null` rather than coercing via SQLite's native sort order. SQLite happily compares `1 < 'a'` as true because of its type-affinity rules — this disagrees with the TCK.
+
+Implement Cypher-conformant null semantics for cross-type ordered comparisons so that affected TCK scenarios pass.
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 
@@ -64,11 +66,17 @@ initiative_id: GQLITE-I-0044
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
-## Acceptance Criteria **[REQUIRED]**
+## Acceptance Criteria
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+- [ ] `1 < 'a'`, `'a' < 1`, `1 < true`, etc. evaluate to `null` (not true/false) in WHERE / RETURN contexts.
+- [ ] Same-type comparisons remain unchanged (no perf or correctness regression).
+- [ ] `null < anything` still returns `null`.
+- [ ] TCK delta: targeted scenarios involving cross-type ordered comparison now pass; no regression elsewhere.
+- [ ] Unit + functional tests added covering the matrix.
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -123,7 +131,13 @@ initiative_id: GQLITE-I-0044
 {Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
 
 ### Technical Approach
-{How this will be implemented}
+Two viable approaches:
+
+1. **`_gql_cmp` SQLite UDF** — register a scalar function `_gql_cmp(a, b)` returning `-1/0/1/null`, then transform `a < b` → `_gql_cmp(a, b) = -1`, etc. Centralizes the semantics but adds UDF dispatch overhead.
+
+2. **Inline CASE** — transform `a < b` → `CASE WHEN typeof(a)=typeof(b) OR (typeof(a) IN ('integer','real') AND typeof(b) IN ('integer','real')) THEN a < b ELSE NULL END`. No UDF needed, but verbose and tricky around stored-as-text JSON values.
+
+Approach 1 is cleaner and matches how we'd add list/path comparison later. Likely path: register UDF in `executor_init`, transform ops in `transform_expr_ops.c`.
 
 ### Dependencies
 {Other tasks or systems this depends on}

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0331.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0331.md
@@ -145,6 +145,17 @@ Approach 1 is cleaner and matches how we'd add list/path comparison later. Likel
 ### Risk Considerations
 {Technical risks and mitigation strategies}
 
-## Status Updates **[REQUIRED]**
+## Status Updates
 
-*To be added during implementation*
+### 2026-05-24 — Implementation complete
+
+The `_gql_order_cmp` UDF infrastructure was already in place (T-0308). Mixed scalar text↔numeric was deliberately preserving SQLite native coerce-to-text behavior, citing WithWhere5. Replaced with Cypher-conformant null semantics, keeping a stringified-boolean escape hatch so Precedence1 [23]/[26] still pass.
+
+**Change** in `src/backend/runtime/udf_helpers.c` `gql_order_cmp_func`:
+- Mixed text↔numeric → null (was: −1 / +1).
+- Exception: text `'true'`/`'false'` is treated as numeric 1/0 (boolean
+  values flow as text on this path; Precedence1 [23]/[26] depend on it).
+
+**TCK delta**: 3573 → 3577 (+4). Gained: Comparison2 [6] x2, Precedence1 [22] x2. No regressions.
+
+**Tests**: unit 944/944, functional exit 0.

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0332.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0332.md
@@ -26,9 +26,21 @@ initiative_id: GQLITE-I-0044
 
 [[GQLITE-I-0044]]
 
-## Objective **[REQUIRED]**
+## Objective
 
-{Clear statement of what this task accomplishes}
+Implement Pattern Comprehension: `[(n)-->(m) | m.x]` and path-assignment form `[p = (n)-->(m) | p]`. Pattern2 [1]-[11].
+
+## Status (2026-05-24, partial — PR #74)
+
++2 TCK (Pattern2 1/11 → 3/11). Remaining 8 need path-hydration inside list elements.
+
+**Done**:
+- Rel-variable registration in comprehension scope ([5]).
+- Grammar productions for `[p = pattern | expr]` and `WHERE` variant (`%expect` 14→15).
+- AST `cypher_pattern_comprehension.path_var`.
+- Transform: synthesize names on anonymous nodes/rels; register `p` as path variable.
+
+**Remaining**: Path projection inside `json_group_array(...)` emits id-array strings. The executor hydrates via `build_path_from_ids` for top-level columns but doesn't descend into list/agg results. Fix: emit fully-hydrated path JSON inline in the comprehension SQL, mirroring node/edge hydration elsewhere.
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0332.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0332.md
@@ -1,0 +1,138 @@
+---
+id: b5-pattern-comprehension-parser
+level: task
+title: "B5: Pattern comprehension parser + lowering — [(n)--&gt;(m) | m.x]"
+short_code: "GQLITE-T-0332"
+created_at: 2026-05-24T14:02:21.916399+00:00
+updated_at: 2026-05-24T14:03:32.398189+00:00
+parent: GQLITE-I-0044
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0044
+---
+
+# B5: Pattern comprehension parser + lowering — [(n)--&gt;(m) | m.x]
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[GQLITE-I-0044]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0333.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0333.md
@@ -1,0 +1,149 @@
+---
+id: b4-write-path-with-where-skip
+level: task
+title: "B4: Write-path WITH/WHERE/SKIP/LIMIT thread-through (Unwind1)"
+short_code: "GQLITE-T-0333"
+created_at: 2026-05-24T14:30:27.898199+00:00
+updated_at: 2026-05-24T14:30:27.898199+00:00
+parent: GQLITE-I-0044
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0044
+---
+
+# B4: Write-path WITH/WHERE/SKIP/LIMIT thread-through (Unwind1)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[GQLITE-I-0044]]
+
+## Objective
+
+Fix WITH/UNWIND scope propagation issues in the write-path / Unwind1 cluster: `RETURN *` column naming, multi-UNWIND chaining, UNWIND-as-scope, UNWIND+MERGE+SET.
+
+## Status (2026-05-24, partial)
+
++2 TCK (Unwind1 [11]/[13]).
+
+**Done**: `RETURN *` expansion now uses `transform_var_get_alias` for projected vars — their `table_alias` is NULL; the column ref lives on `source_expr`. Previously the var was dropped from SELECT and the late `sqlite3_column_name` fallback synthesized the CTE-internal "value" name instead of the user-bound name.
+
+**Remaining**:
+- Unwind1 [12] — `WITH ... UNWIND ... MATCH` empty; second MATCH doesn't join on the carried/unwound vars.
+- Unwind1 [14] — UNWIND + MERGE + SET + RETURN empty; dispatcher path needs SET application + property projection.
+- Unwind1 [6] — CREATE from unwound parameter list.
+
+Each is a separate dispatcher bug.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0333.md
+++ b/.metis/initiatives/GQLITE-I-0044/tasks/GQLITE-T-0333.md
@@ -37,11 +37,17 @@ Fix WITH/UNWIND scope propagation issues in the write-path / Unwind1 cluster: `R
 **Done**: `RETURN *` expansion now uses `transform_var_get_alias` for projected vars — their `table_alias` is NULL; the column ref lives on `source_expr`. Previously the var was dropped from SELECT and the late `sqlite3_column_name` fallback synthesized the CTE-internal "value" name instead of the user-bound name.
 
 **Remaining**:
-- Unwind1 [12] — `WITH ... UNWIND ... MATCH` empty; second MATCH doesn't join on the carried/unwound vars.
-- Unwind1 [14] — UNWIND + MERGE + SET + RETURN empty; dispatcher path needs SET application + property projection.
-- Unwind1 [6] — CREATE from unwound parameter list.
+- Unwind1 [6] — CREATE from unwound parameter list (tracked separately as T-0183: UNWIND $param write paths).
 
-Each is a separate dispatcher bug.
+## Status (2026-05-26)
+
+Most of B4 landed (on PR `i0044-phase-b2-cross-type-cmp`):
+- Unwind1 [12] **DONE** — `WITH a, collect(b) AS bs UNWIND bs AS b2 MATCH (a)-[:Y]->(b2)`. collect() hydrates elements to JSON objects, so the unwound entity's alias is bound to `json_extract(<cte>.value,'$.id')` and behaves like any post-WITH alias_is_id entity. Also fixed the CTE-name extraction in transform_match to tolerate a function-wrapped id alias, and a latent `list_inner_kind` zero-init bug.
+- Unwind1 [14] **DONE** (earlier in this push) — UNWIND+MERGE+SET+RETURN.
+- Create6 **14/14** — the write-path WITH/WHERE/SKIP/LIMIT + aggregate thread-through:
+  [10]/[11] skip/limit after CREATE rels, [12] WITH-WHERE filter, [13] RETURN-aggregate, [7]/[14] aggregating WITH after CREATE. Required: foreach-binding rel properties in execute_create (had no IDENTIFIER case), edge-aware project_aggregate_cell + project_return_row_from_var_map, and a pure-aggregate-WITH collapse in handle_unwind_create_return.
+
+Cumulative B4 TCK: +2 (Unwind1 [11]/[13]) +1 (Unwind1 [12]) +1 (Unwind1 [14]) +6 (Create6) = ~+10. Remaining is just Unwind1 [6] → T-0183.
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 

--- a/.metis/initiatives/GQLITE-I-0046/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0046/initiative.md
@@ -1,0 +1,145 @@
+---
+id: temporal-duration-type-completeness
+level: initiative
+title: "Temporal & Duration Type Completeness"
+short_code: "GQLITE-I-0046"
+created_at: 2026-05-27T02:25:05.547608+00:00
+updated_at: 2026-05-27T02:25:05.547608+00:00
+parent: GQLITE-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: L
+initiative_id: temporal-duration-type-completeness
+---
+
+# Temporal & Duration Type Completeness
+
+## Context **[REQUIRED]**
+
+This is the **C2** work that [[GQLITE-I-0044]] (TCK Conformance Push II)
+explicitly scoped out as its own initiative. During the I-0044 push the
+*contained* temporal failures were closed (Temporal5 accessors, Temporal6
+ISO duration round-trip, offsetSeconds, time tz-strip — see I-0044 status
+2026-05-26). What remains is the genuine **Duration type-system + temporal
+arithmetic** implementation, which needs the exact openCypher/Neo4j semantics
+in hand, not example reverse-engineering.
+
+Durations are stored as a normalized JSON object
+`{_iso8601, months, days, seconds, nanosecondsOfSecond}` (the `_iso8601`
+key marks a value as a duration). The contained accessor/serialization work
+is done; the arithmetic and fractional-composition cascade is not.
+
+**~30 scenarios remain**, in `expressions/temporal/Temporal{2,3,8,10}.feature`.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- **G1**: Correct Duration arithmetic — duration ± duration, duration ×/÷
+  number, with the openCypher carry rules (no sub-day→day carry; fractional
+  remainders cascade months→days→seconds using avg-month conventions).
+- **G2**: `duration.between` / `inMonths` / `inDays` / `inSeconds` and
+  DST-aware temporal differences.
+- **G3**: Fractional-component composition (`duration({years: 12.5, ...})`).
+- **G4**: Calendar week/quarter date construction.
+- **G5**: Named-timezone resolution at `time({timezone:'Name'})` construction.
+- **G6**: Temporal string-parsing edge cases (Temporal2).
+- **G7**: Each change zero-regression (full TCK diff + unit + functional),
+  per the [[GQLITE-I-0044]] verification recipe.
+
+**Non-Goals:**
+- **NOT** a temporal storage-format redesign — the normalized JSON stays.
+- **NOT** a full IANA tzdata embed — expand `named_tz_offset` only as needed.
+- **NOT** temporal features outside the failing TCK set.
+
+## Detailed Design **[REQUIRED]**
+
+Code locus: `src/backend/runtime/udf_helpers.c` (the `_gql_duration_*` /
+`_gql_*_compose` / `_gql_normalize_*` / `_gql_temporal_field` UDFs) and
+`src/backend/transform/transform_func_temporal.c` (construction emission).
+
+### Failing clusters & root causes (from I-0044 investigation)
+
+**D1 — Duration arithmetic (Temporal8 [6]/[7], Temporal10).** `duration ×/÷
+number` returns 0 (the duration JSON is treated as numeric 0); `duration ±
+duration` mis-carries. `*`/`/` are emitted as native SQL in
+`transform_expr_ops.c::transform_binary_operation` (~line 518) — they need a
+`_gql_dyn_mul`/`_gql_dyn_div` like the existing `_gql_dyn_add`/`_gql_dyn_sub`
+(`gql_dyn_addsub_func`). Multiply is per-component (m×n, d×n, totalNs×n);
+**divide carries** months→days→seconds (the example `÷2` of
+P12Y5M14DT16H13M10.0…01S → P6Y2M22DT13H21M8S could not be reconciled with a
+naive per-component divide — needs the exact Neo4j algorithm, likely 30-day
+avg-month carry + day→second carry).
+
+**D2 — Fractional composition (Temporal8 [2]-[5] example 3).** `duration({years:
+12.5, months: 5.5, days: 14.5, ...})` must cascade fractional years→months→
+days→seconds. `gql_duration_compose_func` partially does this but the result
+diverges from expected on the fractional path; the avg-month/day conventions
+need pinning to spec.
+
+**D3 — `duration.between` + DST (Temporal10).** between two temporals in
+months/days/seconds; DST-day handling. `gql_duration_calendar_func` /
+`gql_duration_in_*` exist but are wrong on these.
+
+**D4 — Calendar week/quarter dates (Temporal3 [1], 5 examples).** `date({year,
+week, dayOfWeek})` and quarter selection compute the wrong date (ISO-week math).
+
+**D5 — Named-tz at `time()` construction (Temporal3 [3] 17/19).**
+`time({timezone:'Europe/Stockholm'})` stores `[Name]` with no offset; a `time`
+must resolve to the numeric offset. Expose `named_tz_offset` as a UDF and call
+it from the time() construction in transform_func_temporal.c (~line 282-296);
+`_gql_time_compose` then inherits the offset. (`_gql_normalize_time` already
+strips the bracket as of I-0044.)
+
+**D6 — Temporal parsing (Temporal2 [3]/[5]/[6]/[7]).** time/datetime/named-tz/
+duration string-parse edge cases.
+
+### Reference
+
+The canonical algorithm is Neo4j's `DurationValue` / `TemporalValue`
+(openCypher TCK is generated against it). Acquire the spec/source semantics
+for D1-D3 before implementing — these are not reverse-engineerable from the
+examples (attempted in I-0044, division did not reconcile).
+
+## Alternatives Considered **[REQUIRED]**
+
+- **Store durations as total nanoseconds + total months** (two longs) instead
+  of the JSON object. Rejected for now — the JSON form already round-trips
+  (I-0044 Temporal6) and accessors work; a representation change is a larger,
+  riskier refactor that doesn't itself close scenarios.
+- **Embed full IANA tzdata.** Rejected — overkill; the `named_tz_offset` table
+  covers the TCK zones. Expand per scenario.
+
+## Implementation Plan **[REQUIRED]**
+
+Decompose at pickup (human-driven, per Metis policy). Suggested tasks:
+1. **T: Duration ×/÷ number** — `_gql_dyn_mul`/`_gql_dyn_div` + transform
+   routing. (Temporal8 [7].) Start here; multiply is the simplest.
+2. **T: Duration ± duration carry** + fractional composition cascade.
+   (Temporal8 [2]-[6].) Needs the Neo4j carry algorithm.
+3. **T: duration.between + DST.** (Temporal10.)
+4. **T: Calendar week/quarter date construction.** (Temporal3 [1].)
+5. **T: Named-tz resolution at time() construction.** (Temporal3 [3] 17/19.)
+6. **T: Temporal string-parse edge cases.** (Temporal2.)
+
+## Acceptance Criteria
+
+- [ ] Temporal2/3/8/10 failing scenarios move to pass (target: the ~30 open).
+- [ ] Zero TCK regressions vs the initiative-start baseline; unit 944/944 and
+  functional clean on every PR.
+- [ ] Each landed task notes its TCK delta in this initiative's status log.
+
+## Status Updates
+
+### 2026-05-27 — Created
+
+Filed from the I-0044 temporal investigation (session reached 94.9%). Discovery
+phase. Contained temporal wins already landed under I-0044; this initiative
+owns the deep Duration type-system + arithmetic remainder. Awaiting human
+review before decomposing into tasks.

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -1,0 +1,129 @@
+---
+id: pattern-path-matching-completeness
+level: initiative
+title: "Pattern & Path Matching Completeness"
+short_code: "GQLITE-I-0047"
+created_at: 2026-05-27T02:26:42.947075+00:00
+updated_at: 2026-05-27T02:26:42.947075+00:00
+parent: GQLITE-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: L
+initiative_id: pattern-path-matching-completeness
+---
+
+# Pattern & Path Matching Completeness
+
+## Context **[REQUIRED]**
+
+The structural pattern-matching tail left after [[GQLITE-I-0044]] — the
+**B1 (multi-rel OPTIONAL)** and **C3 (named/variable-length path)** items I-0044
+delegated, plus related MATCH/MERGE emission bugs found during the push. These
+live in `transform_match.c`, the variable-length recursive CTE
+(`cypher_transform.c::generate_varlen_cte`), and the OPTIONAL-MATCH join
+emission. I-0044 landed the contained pieces (single-varlen named-path
+hydration via the interleaved `elem_ids` column; `relationships()` on varlen
+paths; RETURN * synthetic-alias filtering). What remains needs the CTE
+traversal and the outer endpoint/JOIN emission changed *together*.
+
+**~15-18 scenarios** across Match4/5/6/7/9, Pattern1, MatchWhere6, Merge5.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- **G1**: Undirected variable-length (`-[r*]-`) traverses both edge
+  orientations without double-counting.
+- **G2**: Multi-segment / mixed fixed+varlen path chains
+  (`(a)-[*]->(b)-[r]->(c)`, two varlen segments in one path).
+- **G3**: Multi-rel OPTIONAL MATCH join ordering (the "ON clause references
+  tables to its right" error) — combined-EXISTS for full-pattern semantics.
+- **G4**: Named-path forwarded through WITH; OPTIONAL varlen named path returns
+  null (not `[]`) on no-match.
+- **G5**: MATCH+MERGE combined-pattern re-match preserves inline node
+  properties (undirected MERGE no longer double-counts result rows).
+- **G6**: Zero-regression per the [[GQLITE-I-0044]] verification recipe.
+
+**Non-Goals:**
+- **NOT** the sql_builder migration (I-0040/I-0043).
+- **NOT** new pattern syntax (label disjunction etc. → [[GQLITE-I-0045]]).
+- **NOT** pattern *comprehension* lowering (B5 / task GQLITE-T-0332).
+
+## Detailed Design **[REQUIRED]**
+
+### Failing clusters & root causes (from I-0044 investigation)
+
+**P1 — Undirected variable-length (Match9 [1]/[3], Match6 [14], Pattern1
+[10]/[17]/[18]).** `generate_varlen_cte` only traverses `source_id→target_id`,
+so `-[r*0..1]-` misses the reverse direction (row count short). An I-0044
+attempt made the CTE bidirectional (UNION both orientations + recursive
+`e.source_id=end OR e.target_id=end`) — it fixed the count but the *outer*
+undirected endpoint matching then double-counted, regressing Delete4 [2]
+(reverted). **The CTE bidirectional traversal and the outer endpoint-pattern
+emission must be made consistent together** (dedupe one against the other).
+
+**P2 — Multi-segment / mixed fixed+varlen chains (Match5 [25]/[26]/[28],
+Match4 [4]/[5], Match6 [17]).** A path with a varlen rel AND a fixed rel, or
+two varlen segments, returns empty / wrong. The single-varlen `elem_ids`
+hydration (I-0044) is the building block; chains need the segments stitched.
+Match4 [4]'s failure is actually in its *setup* (CREATE rels between
+list-subscript nodes) — a write-path dependency.
+
+**P3 — Multi-rel OPTIONAL MATCH (MatchWhere6 [5]/[7], Match7, Match4 [7]).**
+`OPTIONAL MATCH (x)-[:E1]->(y)-[:E2]->(z) WHERE ...` errors with "ON clause
+references tables to its right" — the LEFT JOIN ON references a not-yet-joined
+table. Needs a combined-EXISTS shape so the full pattern is null-or-all
+(I-0044 B1, residual of T-0320/T-0330).
+
+**P4 — Named path through WITH / OPTIONAL (With1 [4], Match9 [9]).**
+`MATCH p=... WITH p ...` errors "no such column: p" (path var not carried
+through the WITH CTE); OPTIONAL varlen named path returns `[]` instead of null.
+
+**P5 — MATCH+MERGE combined-pattern property drop (Merge5 [12]/[13]).**
+handle_match_merge's RETURN re-matches a synthetic (MATCH ∪ MERGE) pattern;
+inline node properties `{id:2}` are dropped from the generated SQL, so an
+undirected MERGE matches all node pairs → doubled result rows. (Undirected
+edge-find itself was fixed in I-0044; this is the re-match property drop.)
+
+## Alternatives Considered **[REQUIRED]**
+
+- **Post-hoc DISTINCT on undirected results** to mask double-counting.
+  Rejected — wrong semantics (MATCH doesn't dedup; would hide real duplicate
+  rows). The CTE/endpoint emission must be correct, not deduped.
+- **Drop the combined-pattern re-match in MATCH+MERGE** and project from the
+  MERGE var_map directly. Viable for P5 but the var_map currently binds only
+  one row ("just take the first match"); revisit if the property-drop fix
+  proves harder than expected.
+
+## Implementation Plan **[REQUIRED]**
+
+Decompose at pickup. Suggested tasks (roughly independent):
+1. **T: Undirected variable-length** (P1) — CTE + outer endpoint emission
+   together; guard against the Delete4 [2] double-count regression.
+2. **T: Multi-segment / mixed varlen chains** (P2).
+3. **T: Multi-rel OPTIONAL combined-EXISTS** (P3).
+4. **T: Path variable through WITH / OPTIONAL null** (P4).
+5. **T: MATCH+MERGE re-match property preservation** (P5).
+
+## Acceptance Criteria
+
+- [ ] Match4/5/6/7/9, Pattern1, MatchWhere6, Merge5 [12]/[13] failing
+  scenarios move to pass.
+- [ ] Zero TCK regressions (full pass-set diff each PR); unit 944/944 +
+  functional clean. **Specifically re-check Delete4 [2]** (the undirected
+  varlen canary).
+- [ ] Each task logs its TCK delta here.
+
+## Status Updates
+
+### 2026-05-27 — Created
+
+Filed from the I-0044 push (94.9%). Discovery phase. Contained pattern/path
+wins already landed under I-0044; this owns the structural CTE + OPTIONAL +
+combined-pattern remainder. Awaiting human review before decomposition.

--- a/.metis/initiatives/GQLITE-I-0048/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0048/initiative.md
@@ -1,0 +1,138 @@
+---
+id: collection-comparability-semantics
+level: initiative
+title: "Collection & Comparability Semantics"
+short_code: "GQLITE-I-0048"
+created_at: 2026-05-27T02:28:01.761753+00:00
+updated_at: 2026-05-27T02:28:01.761753+00:00
+parent: GQLITE-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: L
+initiative_id: collection-comparability-semantics
+---
+
+# Collection & Comparability Semantics
+
+## Context **[REQUIRED]**
+
+The value-semantics tail left after [[GQLITE-I-0044]]: heterogeneous
+collections that contain graph entities, the full cross-type orderability
+total order, NaN, and a couple of list/aggregation edge cases. I-0044 built
+the **orderability core** — `_gql_order_key` (ORDER BY), `gql_eq_json`
+(list `=`/`IN`), and `_gql_min`/`_gql_max` — all keyed on the total order
+**object < list < text < bool < number < null**. This initiative finishes the
+value model on top of that core.
+
+**~15-20 scenarios** across Comparison1/2, WithOrderBy1, ReturnOrderBy1,
+List12, Quantifier9/11.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- **G1**: Entities inside heterogeneous lists — `UNWIND [n, r, p, 1.5, [..],
+  {..}] AS x` and "sort distinct types". The UNWIND/list-build must carry the
+  MATCH entity aliases into scope, and the sort must use the full cross-type
+  orderability (map < node < rel < list < path < string < bool < number <
+  null per the TCK).
+- **G2**: List-comprehension / pattern-comprehension over collected entities
+  (List12 [1]/[2]/[4]/[5] — `nodes(x)`/`x.id` over a collected/comprehended
+  path element).
+- **G3**: NaN — `0.0/0.0` must produce a NaN value (SQLite returns NULL), with
+  comparison semantics: NaN <op> number = false, NaN = NaN = false. Needs a
+  NaN sentinel threaded through division + comparison + ordering.
+- **G4**: List-equality / quantifier-identity chains — WithOrderBy1 [45]
+  (`orderedX = range(0,n-1)`), Quantifier9/11 [3]/[4]/[5]
+  (`any(...) = NOT none(...)` over a rand/reverse/concat-built list).
+- **G5**: Zero-regression per the [[GQLITE-I-0044]] verification recipe.
+
+**Non-Goals:**
+- **NOT** re-deriving the orderability total order — reuse the I-0044 core.
+- **NOT** temporal value semantics ([[GQLITE-I-0046]]).
+- **NOT** new collection functions — only fixing existing ones.
+
+## Detailed Design **[REQUIRED]**
+
+Core lives in `src/backend/runtime/udf_helpers.c` (`_gql_order_key`,
+`gql_eq_json`, `gql_order_cmp_func`, `_gql_min`/`_gql_max`) +
+`transform_expr_ops.c` (comparison/arithmetic emission) +
+`transform_unwind.c` / list-build.
+
+### Failing clusters & root causes (from I-0044 investigation)
+
+**C1 — Entities in heterogeneous lists / sort distinct types (WithOrderBy1
+[21]/[22], ReturnOrderBy1 [11]/[12], Comparison2 [3]).**
+`MATCH p=(n)-[r]->() UNWIND [n, r, p, 1.5, ['x'], 'y', null, false, {a:1}] AS t
+... ORDER BY t` errors "no such column: _gql_default_alias_0.id" — building the
+list references the MATCH entity aliases, which are out of scope in the UNWIND
+CTE. Two parts: (a) carry the MATCH entity aliases into the list-build/UNWIND
+(extends the carry work from I-0044 Unwind1 [12]); (b) the sort then needs the
+FULL cross-type order including entities (map<node<rel<list<path<scalars). The
+`_gql_order_key` core already orders scalars/lists/objects; extend its object
+branch to distinguish node/rel/path (currently all `{`-objects collapse). Also
+Comparison2 [3]'s residual: booleans-in-lists coerce to int 1, paths encode as
+arrays — entity type fidelity inside lists.
+
+**C2 — List-comprehension / pattern-comprehension over entities (List12
+[1]/[2]/[4]/[5]).** `[x IN collect(n) | ...]` and `nodes(x)` where x is a
+collected/comprehended element — errors "no such column: _unwind_0.value.id"
+and "nodes() argument must be a path variable, got: x".
+
+**C3 — NaN (Comparison1 [8], Comparison2 [5]).** `0.0/0.0` → SQLite NULL, not
+NaN. Cypher: NaN > 1 = false, NaN = NaN = false, NaN <> NaN = true. SQLite
+coerces NaN doubles to NULL, so a **NaN sentinel** must be threaded through a
+`_gql_div` UDF (emit the sentinel for 0.0/0.0) and recognized by
+`gql_order_cmp_func` / `gql_eq_json`. Invasive — touches division, comparison,
+ordering.
+
+**C4 — List-equality / quantifier-identity chains.**
+- WithOrderBy1 [45] (10 examples, ~5 non-temporal): `WITH ... collect(x) ...
+  RETURN orderedX = range(0, n-1)` — ordered-collect + list `=`.
+- Quantifier9/11 [3]/[4]/[5]: `any(...) = NOT none(...)` over a list built via
+  `[y IN inputList WHERE rand()>0.5 | y]` + `reverse` + list-concat across 3
+  UNWIND rounds — data-dependent on the rand/reverse/concat pipeline (the
+  quantifier equality itself works on a plain list; see memory
+  quantifier_equality_dropped).
+
+## Alternatives Considered **[REQUIRED]**
+
+- **NaN as a magic text sentinel** (e.g. `'NaN'`) vs trying to store a real
+  IEEE NaN double. Sentinel is the pragmatic choice — SQLite drops real NaN to
+  NULL. Must be hidden from user-visible output (renders as `NaN`).
+- **Skip C3 (NaN) entirely** — only ~6 scenarios and the most invasive. Could
+  be deferred/dropped if cost outweighs value; record the decision.
+
+## Implementation Plan **[REQUIRED]**
+
+Decompose at pickup. Suggested tasks:
+1. **T: Entities in heterogeneous lists + full orderability** (C1) — highest
+   value (~6); extends the carry + order-key core.
+2. **T: List/pattern-comprehension over entities** (C2).
+3. **T: List-equality / quantifier-identity chains** (C4) — reverse/concat/
+   ordered-collect correctness.
+4. **T: NaN sentinel** (C3) — most invasive; consider last or defer.
+
+## Acceptance Criteria
+
+- [ ] Comparison1/2, WithOrderBy1 [21]/[22]/[45], ReturnOrderBy1 [11]/[12],
+  List12, Quantifier9/11 failing scenarios move to pass (NaN possibly deferred
+  with a recorded decision).
+- [ ] Zero TCK regressions (full pass-set diff each PR); unit 944/944 +
+  functional clean.
+- [ ] Each task logs its TCK delta here.
+
+## Status Updates
+
+### 2026-05-27 — Created
+
+Filed from the I-0044 push (94.9%). Discovery phase. The orderability core
+(_gql_order_key / gql_eq_json / _gql_min/max) already landed under I-0044;
+this initiative builds the entity-in-collection, full-orderability, NaN, and
+list-identity semantics on top. Awaiting human review before decomposition.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -141,3 +141,27 @@ This matrix ships with the GQLITE-I-0035 initiative. Task breakdown:
 - **GQLITE-T-0202** — Fill ON MATCH SET + `SET n +=` on rel gaps.
 - **GQLITE-T-0203** — Fill multi-hop `(a)-[r1]->(b)-[r2]->(c)` read-back gaps.
 - **GQLITE-T-0204** — CI lint: require matrix diff on transform/executor PRs.
+
+---
+
+## Coverage update (2026-05-26) — I-0044 Phase-B conformance push
+
+This PR (#73) lands the I-0044 TCK push (94.9% executable). Round-trip cells
+that flipped from broken/GAP to covered, verified through the openCypher TCK
+harness (`angreal test tck`, full pass-set diff, zero regressions) rather than
+new per-cell functional SQL:
+
+- **`CREATE (n {k: LIST/JSON})` → read-back `n.k`** — list/map literal write
+  now round-trips (previously silently NULL). Backed by the new `*_props_json`
+  property columns in `query_dispatch.c` / `executor_result_project.c`.
+- **`CREATE … RETURN n` with SET-clause + general-expression values** —
+  `handle_create_return` runs the SET loop and an `executor_eval_value`
+  fallback, so computed properties round-trip in the same statement.
+- **`MATCH+MERGE … RETURN`** — handles map/param values and SET, including
+  relationship-variable property read-back (`fetch_edge_prop_*`).
+- **`UNWIND … MERGE … RETURN`** — pure-aggregate WITH collapse + edge cells.
+
+Cross-cutting read-back semantics (orderability total order over
+node/rel/list/map/scalar, list `=`/`IN`, `min`/`max`) also landed; their
+remaining deep tail is tracked in initiatives [[GQLITE-I-0046]] /
+[[GQLITE-I-0047]] / [[GQLITE-I-0048]].

--- a/src/backend/executor/executor_create.c
+++ b/src/backend/executor/executor_create.c
@@ -638,6 +638,34 @@ int execute_path_pattern_with_variables(cypher_executor *executor, cypher_path *
                                     property_value_free(&pv);
                                     continue;
                                 }
+                            } else if (pair->value->type == AST_NODE_IDENTIFIER && g_foreach_ctx) {
+                                /* foreach/UNWIND binding reference, e.g.
+                                 * `UNWIND [1,2,3] AS x CREATE ()-[r {num: x}]->()`.
+                                 * Mirrors the node-property path above. */
+                                cypher_identifier *id = (cypher_identifier*)pair->value;
+                                foreach_binding *binding = get_foreach_binding(g_foreach_ctx, id->name);
+                                if (binding) {
+                                    switch (binding->literal_type) {
+                                        case LITERAL_STRING:
+                                            prop_type = PROP_TYPE_TEXT;
+                                            prop_value = binding->value.string;
+                                            break;
+                                        case LITERAL_INTEGER:
+                                            prop_type = PROP_TYPE_INTEGER;
+                                            prop_value = &binding->value.integer;
+                                            break;
+                                        case LITERAL_DECIMAL:
+                                            prop_type = PROP_TYPE_REAL;
+                                            prop_value = &binding->value.decimal;
+                                            break;
+                                        case LITERAL_BOOLEAN:
+                                            prop_type = PROP_TYPE_BOOLEAN;
+                                            prop_value = &binding->value.boolean;
+                                            break;
+                                        default:
+                                            continue;
+                                    }
+                                }
                             }
 
                             if (prop_value) {

--- a/src/backend/executor/executor_match.c
+++ b/src/backend/executor/executor_match.c
@@ -98,6 +98,10 @@ int execute_match_return_query(cypher_executor *executor, cypher_match *match, c
         for (int vi = 0; vi < var_count; vi++) {
             transform_var *var = transform_var_at(ctx->var_ctx, vi);
             if (!var || !var->is_visible || !var->name) continue;
+            /* RETURN * exposes only user-named variables, not synthetic
+             * aliases for anonymous nodes/rels (With1 [1]/[2]). */
+            if (strncmp(var->name, "_gql_default_alias_", 19) == 0 ||
+                strncmp(var->name, "__unnamed_rel_", 14) == 0) continue;
             /* Create an identifier node referencing this variable */
             ast_node *id_node = (ast_node*)make_identifier(strdup(var->name), -1);
             if (id_node) {

--- a/src/backend/executor/executor_match.c
+++ b/src/backend/executor/executor_match.c
@@ -612,6 +612,46 @@ agtype_value* create_property_agtype_value(const char* value)
     return agtype_value_create_string(value);
 }
 
+/* Create one path element (vertex or edge) by id, hydrating from the DB. */
+static agtype_value *make_path_element(cypher_executor *executor, int64_t element_id,
+                                       bool make_node, const char *first_label)
+{
+    if (make_node) {
+        return agtype_value_create_vertex_with_properties(executor->db, element_id, first_label);
+    }
+    agtype_value *out = NULL;
+    sqlite3_stmt *edge_stmt;
+    const char *edge_sql = "SELECT source_id, target_id, type FROM edges WHERE id = ?";
+    if (sqlite3_prepare_v2(executor->db, edge_sql, -1, &edge_stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_int64(edge_stmt, 1, element_id);
+        if (sqlite3_step(edge_stmt) == SQLITE_ROW) {
+            int64_t source_id = sqlite3_column_int64(edge_stmt, 0);
+            int64_t target_id = sqlite3_column_int64(edge_stmt, 1);
+            const char *type = (const char*)sqlite3_column_text(edge_stmt, 2);
+            out = agtype_value_create_edge_with_properties(executor->db, element_id, type, source_id, target_id);
+        }
+        sqlite3_finalize(edge_stmt);
+    }
+    return out ? out : agtype_value_create_null();
+}
+
+/* Decide whether path element `elem_index` is a node, and its label hint.
+ * For variable-length paths the element kind alternates by position
+ * (even=node, odd=edge); otherwise it follows the AST element. */
+static bool path_elem_is_node(transform_var *path_var, bool is_varlen,
+                              int elem_index, const char **first_label_out)
+{
+    *first_label_out = NULL;
+    if (is_varlen) return (elem_index % 2) == 0;
+    ast_node *element = path_var->path_elements->items[elem_index];
+    if (element->type == AST_NODE_NODE_PATTERN) {
+        cypher_node_pattern *node = (cypher_node_pattern*)element;
+        *first_label_out = has_labels(node) ? get_label_string(node->labels->items[0]) : NULL;
+        return true;
+    }
+    return false;  /* rel (or unknown — treated as edge) */
+}
+
 /* Build a path agtype value from JSON array of element IDs */
 agtype_value* build_path_from_ids(cypher_executor *executor, cypher_transform_context *ctx, const char *path_name, const char *json_ids)
 {
@@ -649,11 +689,39 @@ agtype_value* build_path_from_ids(cypher_executor *executor, cypher_transform_co
     }
     
     CYPHER_DEBUG("build_path_from_ids: Counted %d IDs in JSON", id_count);
-    
-    if (id_count != path_var->path_elements->count) {
+
+    /* A variable-length path emits an interleaved id array of unbounded
+     * length (node,edge,node,...). Its AST has a fixed element count
+     * (e.g. 3 for (n)-[*]->(x)), so the fixed-count check below does not
+     * apply — instead the element kind alternates by position (even=node,
+     * odd=edge). Detect varlen by a rel element carrying ->varlen. */
+    bool is_varlen = false;
+    int rel_count = 0;
+    for (int e = 0; e < path_var->path_elements->count; e++) {
+        if (path_var->path_elements->items[e]->type == AST_NODE_REL_PATTERN) rel_count++;
+    }
+    /* Only a single-varlen-segment path uses the interleaved elem_ids array
+     * (and thus position-parity hydration). Mixed fixed+varlen paths keep the
+     * legacy AST-indexed behavior. Must match the transform_return projection. */
+    if (rel_count == 1) {
+        for (int e = 0; e < path_var->path_elements->count; e++) {
+            ast_node *el = path_var->path_elements->items[e];
+            if (el->type == AST_NODE_REL_PATTERN && ((cypher_rel_pattern*)el)->varlen) {
+                is_varlen = true;
+                break;
+            }
+        }
+    }
+
+    if (!is_varlen && id_count != path_var->path_elements->count) {
         /* Mismatch between expected elements and actual IDs */
-        CYPHER_DEBUG("build_path_from_ids: Mismatch - expected %d elements, got %d IDs", 
+        CYPHER_DEBUG("build_path_from_ids: Mismatch - expected %d elements, got %d IDs",
                      path_var->path_elements->count, id_count);
+        return agtype_value_create_null();
+    }
+    if (is_varlen && (id_count % 2) == 0) {
+        /* Interleaved path must have an odd count (n,e,n,...,n). */
+        CYPHER_DEBUG("build_path_from_ids: varlen id_count %d not odd", id_count);
         return agtype_value_create_null();
     }
     
@@ -679,43 +747,11 @@ agtype_value* build_path_from_ids(cypher_executor *executor, cypher_transform_co
             if (id_pos > 0) {
                 id_buffer[id_pos] = '\0';
                 int64_t element_id = atoll(id_buffer);
-                
-                /* Create agtype value based on element type */
-                ast_node *element = path_var->path_elements->items[elem_index];
-                if (element->type == AST_NODE_NODE_PATTERN) {
-                    /* Create vertex */
-                    cypher_node_pattern *node = (cypher_node_pattern*)element;
-                    const char *first_label = has_labels(node) ? get_label_string(node->labels->items[0]) : NULL;
-                    CYPHER_DEBUG("build_path_from_ids: Creating vertex for element %d with ID %lld", elem_index, (long long)element_id);
-                    path_elements[elem_index] = agtype_value_create_vertex_with_properties(executor->db, element_id, first_label);
-                    CYPHER_DEBUG("build_path_from_ids: Created vertex %p", (void*)path_elements[elem_index]);
-                } else if (element->type == AST_NODE_REL_PATTERN) {
-                    /* Create edge - need to query for edge details */
-                    CYPHER_DEBUG("build_path_from_ids: Creating edge for element %d with ID %lld", elem_index, (long long)element_id);
-                    sqlite3_stmt *edge_stmt;
-                    const char *edge_sql = "SELECT source_id, target_id, type FROM edges WHERE id = ?";
-                    if (sqlite3_prepare_v2(executor->db, edge_sql, -1, &edge_stmt, NULL) == SQLITE_OK) {
-                        sqlite3_bind_int64(edge_stmt, 1, element_id);
-                        if (sqlite3_step(edge_stmt) == SQLITE_ROW) {
-                            int64_t source_id = sqlite3_column_int64(edge_stmt, 0);
-                            int64_t target_id = sqlite3_column_int64(edge_stmt, 1);
-                            const char *type = (const char*)sqlite3_column_text(edge_stmt, 2);
-                            path_elements[elem_index] = agtype_value_create_edge_with_properties(executor->db, element_id, type, source_id, target_id);
-                            CYPHER_DEBUG("build_path_from_ids: Created edge %p", (void*)path_elements[elem_index]);
-                        } else {
-                            CYPHER_DEBUG("build_path_from_ids: No edge found for ID %lld", (long long)element_id);
-                            path_elements[elem_index] = agtype_value_create_null();
-                        }
-                        sqlite3_finalize(edge_stmt);
-                    } else {
-                        CYPHER_DEBUG("build_path_from_ids: Failed to prepare edge query");
-                        path_elements[elem_index] = agtype_value_create_null();
-                    }
-                } else {
-                    CYPHER_DEBUG("build_path_from_ids: Unknown element type at index %d", elem_index);
-                    path_elements[elem_index] = agtype_value_create_null();
-                }
-                
+
+                const char *first_label = NULL;
+                bool make_node = path_elem_is_node(path_var, is_varlen, elem_index, &first_label);
+                path_elements[elem_index] = make_path_element(executor, element_id, make_node, first_label);
+
                 elem_index++;
                 id_pos = 0;
                 CYPHER_DEBUG("build_path_from_ids: Finished element %d, moving to next", elem_index - 1);
@@ -730,42 +766,10 @@ agtype_value* build_path_from_ids(cypher_executor *executor, cypher_transform_co
         int64_t element_id = atoll(id_buffer);
         
         CYPHER_DEBUG("build_path_from_ids: Processing final element %d with ID %lld", elem_index, (long long)element_id);
-        
-        /* Create agtype value based on element type */
-        ast_node *element = path_var->path_elements->items[elem_index];
-        if (element->type == AST_NODE_NODE_PATTERN) {
-            /* Create vertex */
-            cypher_node_pattern *node = (cypher_node_pattern*)element;
-            const char *first_label = has_labels(node) ? get_label_string(node->labels->items[0]) : NULL;
-            CYPHER_DEBUG("build_path_from_ids: Creating vertex for element %d with ID %lld", elem_index, (long long)element_id);
-            path_elements[elem_index] = agtype_value_create_vertex_with_properties(executor->db, element_id, first_label);
-            CYPHER_DEBUG("build_path_from_ids: Created vertex %p", (void*)path_elements[elem_index]);
-        } else if (element->type == AST_NODE_REL_PATTERN) {
-            /* Create edge - need to query for edge details */
-            CYPHER_DEBUG("build_path_from_ids: Creating edge for element %d with ID %lld", elem_index, (long long)element_id);
-            sqlite3_stmt *edge_stmt;
-            const char *edge_sql = "SELECT source_id, target_id, type FROM edges WHERE id = ?";
-            if (sqlite3_prepare_v2(executor->db, edge_sql, -1, &edge_stmt, NULL) == SQLITE_OK) {
-                sqlite3_bind_int64(edge_stmt, 1, element_id);
-                if (sqlite3_step(edge_stmt) == SQLITE_ROW) {
-                    int64_t source_id = sqlite3_column_int64(edge_stmt, 0);
-                    int64_t target_id = sqlite3_column_int64(edge_stmt, 1);
-                    const char *type = (const char*)sqlite3_column_text(edge_stmt, 2);
-                    path_elements[elem_index] = agtype_value_create_edge_with_properties(executor->db, element_id, type, source_id, target_id);
-                    CYPHER_DEBUG("build_path_from_ids: Created edge %p", (void*)path_elements[elem_index]);
-                } else {
-                    CYPHER_DEBUG("build_path_from_ids: No edge found for ID %lld", (long long)element_id);
-                    path_elements[elem_index] = agtype_value_create_null();
-                }
-                sqlite3_finalize(edge_stmt);
-            } else {
-                CYPHER_DEBUG("build_path_from_ids: Failed to prepare edge query");
-                path_elements[elem_index] = agtype_value_create_null();
-            }
-        } else {
-            CYPHER_DEBUG("build_path_from_ids: Unknown element type at index %d", elem_index);
-            path_elements[elem_index] = agtype_value_create_null();
-        }
+
+        const char *first_label = NULL;
+        bool make_node = path_elem_is_node(path_var, is_varlen, elem_index, &first_label);
+        path_elements[elem_index] = make_path_element(executor, element_id, make_node, first_label);
         elem_index++;
     }
     

--- a/src/backend/executor/executor_merge.c
+++ b/src/backend/executor/executor_merge.c
@@ -274,10 +274,20 @@ int find_edge_by_pattern(cypher_executor *executor, int source_id, int target_id
     param_binding bindings[MAX_BINDINGS];
     int bind_count = 0;
 
-    /* source_id and target_id are integers from our own code, safe to interpolate */
-    offset += snprintf(sql + offset, sizeof(sql) - offset,
-                       "SELECT e.id FROM edges e WHERE e.source_id = %d AND e.target_id = %d",
-                       source_id, target_id);
+    /* source_id and target_id are integers from our own code, safe to interpolate.
+     * For an undirected pattern (a)-[r]-(b) the existing edge may run either
+     * way, so match both orientations (Merge5 [12]/[13]). */
+    bool undirected = rel_pattern && !rel_pattern->left_arrow && !rel_pattern->right_arrow;
+    if (undirected) {
+        offset += snprintf(sql + offset, sizeof(sql) - offset,
+                           "SELECT e.id FROM edges e WHERE ((e.source_id = %d AND e.target_id = %d)"
+                           " OR (e.source_id = %d AND e.target_id = %d))",
+                           source_id, target_id, target_id, source_id);
+    } else {
+        offset += snprintf(sql + offset, sizeof(sql) - offset,
+                           "SELECT e.id FROM edges e WHERE e.source_id = %d AND e.target_id = %d",
+                           source_id, target_id);
+    }
 
     /* Add type filter if specified - use parameter binding */
     if (type && bind_count < MAX_BINDINGS) {

--- a/src/backend/executor/executor_result_project.c
+++ b/src/backend/executor/executor_result_project.c
@@ -217,6 +217,48 @@ static bool fetch_node_prop_double(cypher_executor *executor, int node_id,
     return false;
 }
 
+static bool fetch_edge_prop_int(cypher_executor *executor, int edge_id,
+                                const char *prop_name, int64_t *out) {
+    const char *type_tables[] = {"edge_props_int", "edge_props_real", "edge_props_text", NULL};
+    for (int t = 0; type_tables[t]; t++) {
+        char sql[512];
+        snprintf(sql, sizeof(sql),
+            "SELECT value FROM %s WHERE edge_id = %d AND key_id = "
+            "(SELECT id FROM property_keys WHERE key = '%s')",
+            type_tables[t], edge_id, prop_name);
+        sqlite3_stmt *stmt;
+        if (sqlite3_prepare_v2(executor->db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+            int rc = sqlite3_step(stmt);
+            bool got = false;
+            if (rc == SQLITE_ROW) { *out = sqlite3_column_int64(stmt, 0); got = true; }
+            sqlite3_finalize(stmt);
+            if (got) return true;
+        }
+    }
+    return false;
+}
+
+static bool fetch_edge_prop_double(cypher_executor *executor, int edge_id,
+                                   const char *prop_name, double *out) {
+    const char *type_tables[] = {"edge_props_real", "edge_props_int", NULL};
+    for (int t = 0; type_tables[t]; t++) {
+        char sql[512];
+        snprintf(sql, sizeof(sql),
+            "SELECT value FROM %s WHERE edge_id = %d AND key_id = "
+            "(SELECT id FROM property_keys WHERE key = '%s')",
+            type_tables[t], edge_id, prop_name);
+        sqlite3_stmt *stmt;
+        if (sqlite3_prepare_v2(executor->db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+            int rc = sqlite3_step(stmt);
+            bool got = false;
+            if (rc == SQLITE_ROW) { *out = sqlite3_column_double(stmt, 0); got = true; }
+            sqlite3_finalize(stmt);
+            if (got) return true;
+        }
+    }
+    return false;
+}
+
 /* Compute an aggregate over a list of var_maps for a single RETURN item.
  * Writes a result cell into result->data[0][col_idx]. */
 void project_aggregate_cell(cypher_executor *executor,
@@ -247,8 +289,11 @@ void project_aggregate_cell(cypher_executor *executor,
             if (var_name) {
                 for (int m = 0; m < n_maps; m++) {
                     int nid = get_variable_node_id(maps[m], var_name);
+                    int eid = (nid < 0) ? get_variable_edge_id(maps[m], var_name) : -1;
                     int64_t tmp;
                     if (nid >= 0 && fetch_node_prop_int(executor, nid, prop->property_name, &tmp))
+                        cnt++;
+                    else if (eid >= 0 && fetch_edge_prop_int(executor, eid, prop->property_name, &tmp))
                         cnt++;
                 }
             }
@@ -279,16 +324,21 @@ void project_aggregate_cell(cypher_executor *executor,
     int64_t isum = 0, imin = 0, imax = 0;
     for (int m = 0; m < n_maps; m++) {
         int nid = get_variable_node_id(maps[m], var_name);
-        if (nid < 0) continue;
+        int eid = (nid < 0) ? get_variable_edge_id(maps[m], var_name) : -1;
+        if (nid < 0 && eid < 0) continue;
         int64_t iv;
         double dv;
-        if (fetch_node_prop_int(executor, nid, prop->property_name, &iv)) {
+        bool got_int = (nid >= 0)
+            ? fetch_node_prop_int(executor, nid, prop->property_name, &iv)
+            : fetch_edge_prop_int(executor, eid, prop->property_name, &iv);
+        if (got_int) {
             dv = (double)iv;
-        } else if (fetch_node_prop_double(executor, nid, prop->property_name, &dv)) {
-            all_int = false;
-            iv = (int64_t)dv;
         } else {
-            continue;
+            bool got_dbl = (nid >= 0)
+                ? fetch_node_prop_double(executor, nid, prop->property_name, &dv)
+                : fetch_edge_prop_double(executor, eid, prop->property_name, &dv);
+            if (got_dbl) { all_int = false; iv = (int64_t)dv; }
+            else continue;
         }
         if (seen == 0) {
             isum = iv; imin = iv; imax = iv;
@@ -353,24 +403,32 @@ void project_return_row_from_var_map(cypher_executor *executor,
             }
             if (var_name && prop_name) {
                 int node_id = get_variable_node_id(var_map, var_name);
-                if (node_id >= 0) {
-                    const char *type_tables[] = {
+                int edge_id = (node_id < 0) ? get_variable_edge_id(var_map, var_name) : -1;
+                const char *id_col = node_id >= 0 ? "node_id" : "edge_id";
+                int ent_id = node_id >= 0 ? node_id : edge_id;
+                if (ent_id >= 0) {
+                    const char *node_tables[] = {
                         "node_props_text", "node_props_int",
                         "node_props_real", "node_props_bool", NULL
                     };
+                    const char *edge_tables[] = {
+                        "edge_props_text", "edge_props_int",
+                        "edge_props_real", "edge_props_bool", NULL
+                    };
+                    const char **type_tables = node_id >= 0 ? node_tables : edge_tables;
                     for (int t = 0; type_tables[t]; t++) {
                         char sql[512];
                         snprintf(sql, sizeof(sql),
-                            "SELECT value FROM %s WHERE node_id = %d AND key_id = "
+                            "SELECT value FROM %s WHERE %s = %d AND key_id = "
                             "(SELECT id FROM property_keys WHERE key = '%s')",
-                            type_tables[t], node_id, prop_name);
+                            type_tables[t], id_col, ent_id, prop_name);
                         sqlite3_stmt *stmt;
                         if (sqlite3_prepare_v2(executor->db, sql, -1, &stmt, NULL) == SQLITE_OK) {
                             if (sqlite3_step(stmt) == SQLITE_ROW) {
                                 int sql_type = sqlite3_column_type(stmt, 0);
                                 const char *val = (const char*)sqlite3_column_text(stmt, 0);
                                 if (val) {
-                                    if (strcmp(type_tables[t], "node_props_bool") == 0) {
+                                    if (strstr(type_tables[t], "_props_bool")) {
                                         result->data[row_idx][i] = strdup(atoi(val) ? "true" : "false");
                                         result->data_types[row_idx][i] = SQLITE_TEXT;
                                     } else {

--- a/src/backend/executor/executor_result_project.c
+++ b/src/backend/executor/executor_result_project.c
@@ -409,11 +409,11 @@ void project_return_row_from_var_map(cypher_executor *executor,
                 if (ent_id >= 0) {
                     const char *node_tables[] = {
                         "node_props_text", "node_props_int",
-                        "node_props_real", "node_props_bool", NULL
+                        "node_props_real", "node_props_bool", "node_props_json", NULL
                     };
                     const char *edge_tables[] = {
                         "edge_props_text", "edge_props_int",
-                        "edge_props_real", "edge_props_bool", NULL
+                        "edge_props_real", "edge_props_bool", "edge_props_json", NULL
                     };
                     const char **type_tables = node_id >= 0 ? node_tables : edge_tables;
                     for (int t = 0; type_tables[t]; t++) {

--- a/src/backend/executor/executor_set.c
+++ b/src/backend/executor/executor_set.c
@@ -173,6 +173,15 @@ int executor_eval_predicate(cypher_executor *executor,
     }
 }
 
+/* Public value-returning evaluator: evaluate `expr` against `var_map` and
+ * return its value via out params. Returns 0 (value), -1 (error), -2 (NULL).
+ * Used by CREATE+RETURN to project general expressions. */
+int executor_eval_value(cypher_executor *executor, ast_node *expr,
+                        variable_map *var_map, property_type *out_type,
+                        property_value *out_value) {
+    return evaluate_ast_with_context(executor, expr, var_map, out_type, out_value);
+}
+
 /* Evaluate a function call by transforming to SQL and executing via SQLite.
  * Returns 0 on success, -1 on error, -2 for NULL result. */
 int evaluate_function_call_via_sqlite(

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -2186,6 +2186,80 @@ static int handle_unwind_create_return(cypher_executor *executor, cypher_query *
         }
     }
 
+    /* B4: aggregating WITH between CREATE and RETURN, e.g.
+     *   UNWIND [..] AS x CREATE (n {num:x}) WITH sum(n.num) AS s RETURN s
+     * When the WITH is pure-aggregate (every item is an aggregate, no
+     * grouping keys) it collapses the per-iteration maps to one row. Compute
+     * each WITH aggregate across `maps`, then satisfy RETURN by resolving its
+     * references to the WITH aliases. (Create6 [7]/[14].) */
+    {
+        cypher_with *agg_w = NULL;
+        if (query->clauses) {
+            for (int ci = 0; ci < query->clauses->count; ci++) {
+                ast_node *cl = query->clauses->items[ci];
+                if (cl->type != AST_NODE_WITH) continue;
+                cypher_with *w = (cypher_with *)cl;
+                bool has_agg = false, has_key = false;
+                if (w->items) {
+                    for (int wi = 0; wi < w->items->count; wi++) {
+                        cypher_return_item *it = (cypher_return_item *)w->items->items[wi];
+                        if (it && aggregating_call_name(it->expr)) has_agg = true;
+                        else has_key = true;
+                    }
+                }
+                if (has_agg && !has_key) { agg_w = w; break; }
+            }
+        }
+        if (agg_w) {
+            int wn = agg_w->items->count;
+            char **wvals = calloc(wn, sizeof(char*));
+            int *wtypes = calloc(wn, sizeof(int));
+            const char **walias = calloc(wn, sizeof(char*));
+            for (int wi = 0; wi < wn; wi++) {
+                cypher_return_item *it = (cypher_return_item *)agg_w->items->items[wi];
+                walias[wi] = it->alias;
+                cypher_result tmp;
+                memset(&tmp, 0, sizeof(tmp));
+                tmp.data = malloc(sizeof(char**));
+                tmp.data[0] = calloc(1, sizeof(char*));
+                tmp.data_types = malloc(sizeof(int*));
+                tmp.data_types[0] = calloc(1, sizeof(int));
+                project_aggregate_cell(executor, it, maps, n_maps, &tmp, 0);
+                wvals[wi] = tmp.data[0][0];
+                wtypes[wi] = tmp.data_types[0][0];
+                free(tmp.data[0]); free(tmp.data);
+                free(tmp.data_types[0]); free(tmp.data_types);
+            }
+            result->row_count = 1;
+            result->data = malloc(sizeof(char**));
+            result->data_types = malloc(sizeof(int*));
+            result->data[0] = malloc(col_count * sizeof(char*));
+            result->data_types[0] = calloc(col_count, sizeof(int));
+            for (int i = 0; i < col_count; i++) {
+                cypher_return_item *rit = (cypher_return_item *)ret->items->items[i];
+                result->data[0][i] = NULL;
+                const char *ref = NULL;
+                if (rit->expr && rit->expr->type == AST_NODE_IDENTIFIER)
+                    ref = ((cypher_identifier *)rit->expr)->name;
+                if (ref) {
+                    for (int wi = 0; wi < wn; wi++) {
+                        if (walias[wi] && strcmp(walias[wi], ref) == 0) {
+                            result->data[0][i] = wvals[wi] ? strdup(wvals[wi]) : NULL;
+                            result->data_types[0][i] = wtypes[wi];
+                            break;
+                        }
+                    }
+                }
+            }
+            for (int wi = 0; wi < wn; wi++) free(wvals[wi]);
+            free(wvals); free(wtypes); free(walias);
+            for (int j = 0; j < n_maps; j++) free_variable_map(maps[j]);
+            free(maps);
+            result->success = true;
+            return 0;
+        }
+    }
+
     /* SKIP/LIMIT */
     int64_t limit_val = -1, skip_val = 0;
     if (ret->limit && ret->limit->type == AST_NODE_LITERAL) {

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -1833,6 +1833,18 @@ static int handle_create_return(cypher_executor *executor, cypher_query *query,
         }
     }
 
+    /* Run any SET clauses between CREATE and RETURN against the created
+     * bindings, in document order (CREATE (a {..}) SET a.x = .. RETURN a.x).
+     * Previously the CREATE+RETURN handler ignored SET entirely. (Set1 [6]/[7].) */
+    for (int i = 0; var_map && query->clauses && i < query->clauses->count; i++) {
+        ast_node *clause = query->clauses->items[i];
+        if (clause->type != AST_NODE_SET) continue;
+        if (execute_set_operations(executor, (cypher_set *)clause, var_map, result) < 0) {
+            free_variable_map(var_map);
+            return -1;
+        }
+    }
+
     if (!var_map || var_map->count == 0 || !ret || !ret->items) {
         result->success = true;
         if (var_map) free_variable_map(var_map);
@@ -1927,11 +1939,11 @@ static int handle_create_return(cypher_executor *executor, cypher_query *query,
                     /* Query each property type table for the value */
                     const char *node_tables[] = {
                         "node_props_text", "node_props_int",
-                        "node_props_real", "node_props_bool", NULL
+                        "node_props_real", "node_props_bool", "node_props_json", NULL
                     };
                     const char *edge_tables[] = {
                         "edge_props_text", "edge_props_int",
-                        "edge_props_real", "edge_props_bool", NULL
+                        "edge_props_real", "edge_props_bool", "edge_props_json", NULL
                     };
                     const char **type_tables = is_edge ? edge_tables : node_tables;
                     const char *id_col = is_edge ? "edge_id" : "node_id";

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -2282,50 +2282,99 @@ static int handle_unwind_merge_return(cypher_executor *executor, cypher_query *q
         set_result_error(result, "UNWIND+MERGE+RETURN: missing clause");
         return -1;
     }
-    if (unwind->expr->type != AST_NODE_LIST) {
-        set_result_error(result, "UNWIND+MERGE+RETURN requires a list literal");
-        return -1;
-    }
-    cypher_list *list = (cypher_list*)unwind->expr;
-
     set_return_column_names(ret, result);
     int col_count = ret->items->count;
-    if (!list->items || list->items->count == 0) {
-        result->row_count = 0;
-        result->data = NULL;
-        result->data_types = NULL;
-        result->success = true;
-        return 0;
-    }
 
     foreach_context *ctx = create_foreach_context();
     if (!ctx) { set_result_error(result, "Failed to create foreach context"); return -1; }
     foreach_context *prev_ctx = g_foreach_ctx;
     g_foreach_ctx = ctx;
 
-    int cap = list->items->count;
+    /* Initial capacity grows as we iterate. */
+    int cap = 8;
     variable_map **maps = calloc(cap, sizeof(variable_map*));
     int n_maps = 0;
 
-    for (int i = 0; i < list->items->count; i++) {
-        ast_node *item = list->items->items[i];
-        if (item->type != AST_NODE_LITERAL) continue;
-        cypher_literal *lit = (cypher_literal*)item;
-        switch (lit->literal_type) {
-            case LITERAL_INTEGER: set_foreach_binding_int(ctx, unwind->alias, lit->value.integer); break;
-            case LITERAL_STRING: set_foreach_binding_string(ctx, unwind->alias, lit->value.string); break;
-            case LITERAL_DECIMAL: set_foreach_binding_int(ctx, unwind->alias, (int64_t)lit->value.decimal); break;
-            default: continue;
+    cypher_set *set = find_set_clause(query);
+
+    /* Inner per-iteration body: MERGE + optional SET, append to maps[]. */
+    int err_out = 0;
+    #define UMR_RUN_BODY() do { \
+        variable_map *vm = NULL; \
+        if (execute_merge_clause(executor, merge, result, NULL, &vm) < 0) { err_out = -1; break; } \
+        if (set && vm) { (void)execute_set_operations(executor, set, vm, result); } \
+        if (vm) { \
+            if (n_maps == cap) { cap *= 2; maps = realloc(maps, cap * sizeof(variable_map*)); } \
+            maps[n_maps++] = vm; \
+        } \
+    } while (0)
+
+    if (unwind->expr->type == AST_NODE_LIST) {
+        cypher_list *list = (cypher_list*)unwind->expr;
+        if (list->items) {
+            for (int i = 0; i < list->items->count; i++) {
+                ast_node *item = list->items->items[i];
+                if (item->type == AST_NODE_LITERAL) {
+                    cypher_literal *lit = (cypher_literal*)item;
+                    switch (lit->literal_type) {
+                        case LITERAL_INTEGER: set_foreach_binding_int(ctx, unwind->alias, lit->value.integer); break;
+                        case LITERAL_STRING: set_foreach_binding_string(ctx, unwind->alias, lit->value.string); break;
+                        case LITERAL_DECIMAL: set_foreach_binding_int(ctx, unwind->alias, (int64_t)lit->value.decimal); break;
+                        default: continue;
+                    }
+                } else if (item->type == AST_NODE_MAP || item->type == AST_NODE_LIST) {
+                    char *js = serialize_ast_to_json(item);
+                    if (!js) continue;
+                    set_foreach_binding_string(ctx, unwind->alias, js);
+                    free(js);
+                } else continue;
+                UMR_RUN_BODY();
+                if (err_out) break;
+            }
         }
-        variable_map *vm = NULL;
-        if (execute_merge_clause(executor, merge, result, NULL, &vm) < 0) {
-            for (int j = 0; j < n_maps; j++) free_variable_map(maps[j]);
-            free(maps);
-            g_foreach_ctx = prev_ctx;
-            free_foreach_context(ctx);
-            return -1;
+    } else if (unwind->expr->type == AST_NODE_PARAMETER) {
+        cypher_parameter *param = (cypher_parameter*)unwind->expr;
+        if (!executor->params_json) {
+            set_result_error(result, "UNWIND $param requires parameters");
+            free(maps); g_foreach_ctx = prev_ctx; free_foreach_context(ctx); return -1;
         }
-        if (vm) maps[n_maps++] = vm;
+        char sql[512];
+        snprintf(sql, sizeof(sql),
+                 "SELECT value FROM json_each(json_extract(?, '$.%s'))", param->name);
+        sqlite3_stmt *stmt;
+        if (sqlite3_prepare_v2(executor->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+            set_result_error(result, "Failed to prepare UNWIND parameter query");
+            free(maps); g_foreach_ctx = prev_ctx; free_foreach_context(ctx); return -1;
+        }
+        sqlite3_bind_text(stmt, 1, executor->params_json, -1, SQLITE_STATIC);
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            int ct = sqlite3_column_type(stmt, 0);
+            if (ct == SQLITE_TEXT) {
+                set_foreach_binding_string(ctx, unwind->alias,
+                    (const char*)sqlite3_column_text(stmt, 0));
+            } else if (ct == SQLITE_INTEGER) {
+                set_foreach_binding_int(ctx, unwind->alias, sqlite3_column_int64(stmt, 0));
+            } else { continue; }
+            UMR_RUN_BODY();
+            if (err_out) break;
+        }
+        sqlite3_finalize(stmt);
+    } else {
+        set_result_error(result, "UNWIND+MERGE+RETURN requires a list literal or parameter");
+        free(maps); g_foreach_ctx = prev_ctx; free_foreach_context(ctx); return -1;
+    }
+    #undef UMR_RUN_BODY
+    if (err_out) {
+        for (int j = 0; j < n_maps; j++) free_variable_map(maps[j]);
+        free(maps);
+        g_foreach_ctx = prev_ctx;
+        free_foreach_context(ctx);
+        return -1;
+    }
+    if (n_maps == 0) {
+        result->row_count = 0;
+        result->data = NULL;
+        result->data_types = NULL;
     }
 
     g_foreach_ctx = prev_ctx;

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -643,6 +643,7 @@ int handle_generic_transform(cypher_executor *executor, cypher_query *query,
         return -1;
     }
 
+
     /* T-0310: run pre_exec_dml (compound DML from SET/REMOVE/DELETE
      * that precedes a read) before stepping the prepared SELECT. */
     if (transform_result->pre_exec_dml) {

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -2066,6 +2066,27 @@ static int handle_create_return(cypher_executor *executor, cypher_query *query,
                     }
                 }
             }
+        } else if (expr) {
+            /* Any other expression (binary op, subscript like n['na'+'e'],
+             * list/map literal, ...) — evaluate against the created bindings.
+             * (Graph7 [2]/[3], RETURN a.numbers + [..], etc.) */
+            property_type pt; property_value pv; property_value_init(&pv);
+            int erc = executor_eval_value(executor, expr, var_map, &pt, &pv);
+            if (erc == 0) {
+                if (pt == PROP_TYPE_INTEGER) {
+                    char b[32]; snprintf(b, sizeof(b), "%lld", (long long)pv.as_int);
+                    result->data[0][i] = strdup(b);
+                    result->data_types[0][i] = SQLITE_INTEGER;
+                } else if (pt == PROP_TYPE_REAL) {
+                    char b[64]; snprintf(b, sizeof(b), "%g", pv.as_real);
+                    result->data[0][i] = strdup(b);
+                    result->data_types[0][i] = SQLITE_FLOAT;
+                } else if (pv.as_str) {
+                    result->data[0][i] = strdup(pv.as_str);
+                    result->data_types[0][i] = SQLITE_TEXT;
+                }
+            }
+            property_value_free(&pv);
         }
     }
 

--- a/src/backend/parser/cypher_ast.c
+++ b/src/backend/parser/cypher_ast.c
@@ -515,6 +515,9 @@ void ast_node_free(ast_node *node)
                 if (comp->collect_expr) {
                     ast_node_free(comp->collect_expr);
                 }
+                if (comp->path_var) {
+                    free(comp->path_var);
+                }
             }
             break;
 
@@ -1309,6 +1312,7 @@ cypher_pattern_comprehension* make_pattern_comprehension(ast_list *pattern, ast_
     comp->pattern = pattern;
     comp->where_expr = where_expr;
     comp->collect_expr = collect_expr;
+    comp->path_var = NULL;
     return comp;
 }
 

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -156,6 +156,9 @@ int cypher_yylex(CYPHER_YYSTYPE *yylval, CYPHER_YYLTYPE *yylloc, cypher_parser_c
 %left '^'
 %left IN IS
 %left '.' '['
+/* Unary -/+ bind tightest among arithmetic: `-3^2` = (-3)^2 = 9
+ * (Precedence2 [4]). Negation of a non-literal is materialized as 0 - expr
+ * in the '-' expr production. */
 %right UNARY_MINUS UNARY_PLUS
 
 %%
@@ -1202,12 +1205,16 @@ expr:
                 lit->value.decimal = -lit->value.decimal;
                 $$ = $2;
             } else {
-                /* For other types, we'd need a unary minus node */
-                $$ = $2;
+                /* Non-numeric literal: negate as 0 - lit. */
+                $$ = (ast_node*)make_binary_op(BINARY_OP_SUB,
+                        (ast_node*)make_integer_literal(0, @1.first_line), $2, @1.first_line);
             }
         } else {
-            /* For non-literals, we'd need a unary minus expression node */
-            $$ = $2;
+            /* Non-literal operand (e.g. -3^2, -x, -(a+b)): build a real
+             * negation as 0 - expr; previously the negation was silently
+             * dropped. (Precedence2 [4]/[5].) */
+            $$ = (ast_node*)make_binary_op(BINARY_OP_SUB,
+                    (ast_node*)make_integer_literal(0, @1.first_line), $2, @1.first_line);
         }
     }
     | expr '+' expr     { $$ = (ast_node*)make_binary_op(BINARY_OP_ADD, $1, $3, @2.first_line); }

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -38,7 +38,7 @@ int cypher_yylex(CYPHER_YYSTYPE *yylval, CYPHER_YYLTYPE *yylloc, cypher_parser_c
  * parser can't immediately distinguish a node pattern from a parenthesized
  * expression until it sees more context (e.g., a following rel_pattern).
  */
-%expect 14
+%expect 15
 %expect-rr 3  /* IDENTIFIER, BQIDENT, END_P in variable_opt */
 
 %union {
@@ -1596,6 +1596,37 @@ pattern_comprehension:
             ast_list *pattern = ast_list_create();
             ast_list_append(pattern, (ast_node*)path);
             $$ = (ast_node*)make_pattern_comprehension(pattern, $10, $12, @1.first_line);
+        }
+    /* T-0332: path-assignment form `[p = (...)-->(...) | expr]` */
+    | '[' IDENTIFIER '=' '(' variable_opt label_opt properties_opt ')' rel_pattern node_pattern '|' expr ']'
+        {
+            cypher_node_pattern *first = make_node_pattern($5, $6, (ast_node*)$7);
+            ast_list *elements = ast_list_create();
+            ast_list_append(elements, (ast_node*)first);
+            ast_list_append(elements, (ast_node*)$9);
+            ast_list_append(elements, (ast_node*)$10);
+            cypher_path *path = make_path(elements);
+
+            ast_list *pattern = ast_list_create();
+            ast_list_append(pattern, (ast_node*)path);
+            cypher_pattern_comprehension *pc = make_pattern_comprehension(pattern, NULL, $12, @1.first_line);
+            pc->path_var = strdup($2);
+            $$ = (ast_node*)pc;
+        }
+    | '[' IDENTIFIER '=' '(' variable_opt label_opt properties_opt ')' rel_pattern node_pattern WHERE expr '|' expr ']'
+        {
+            cypher_node_pattern *first = make_node_pattern($5, $6, (ast_node*)$7);
+            ast_list *elements = ast_list_create();
+            ast_list_append(elements, (ast_node*)first);
+            ast_list_append(elements, (ast_node*)$9);
+            ast_list_append(elements, (ast_node*)$10);
+            cypher_path *path = make_path(elements);
+
+            ast_list *pattern = ast_list_create();
+            ast_list_append(pattern, (ast_node*)path);
+            cypher_pattern_comprehension *pc = make_pattern_comprehension(pattern, $12, $14, @1.first_line);
+            pc->path_var = strdup($2);
+            $$ = (ast_node*)pc;
         }
     ;
 

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -1134,6 +1134,74 @@ void gql_order_key_func(
     sqlite3_result_value(context, argv[0]);
 }
 
+/* --- Cypher-orderability min()/max() aggregates (Aggregation2 [9]/[11]/[12]).
+ * SQLite's native MIN/MAX use storage-class order, which mis-orders mixed-type
+ * and list values. These custom aggregates keep the element whose Cypher
+ * order-key (same total order as _gql_order_key: object < list < text < bool
+ * < number < null) is smallest/largest, ignoring nulls, and return the
+ * original typed value via sqlite3_value_dup so type is preserved. --- */
+
+/* Build a Cypher order-key for any single value into a malloc'd string. */
+static char *okey_for_value(sqlite3 *db, sqlite3_value *v) {
+    char *b = NULL; size_t n = 0, cap = 0;
+    int t = sqlite3_value_type(v);
+    if (t == SQLITE_INTEGER || t == SQLITE_FLOAT) {
+        okey_append(&b, &n, &cap, "7", 1);
+        okey_num(&b, &n, &cap, sqlite3_value_double(v));
+    } else if (t == SQLITE_TEXT) {
+        const char *s = (const char*)sqlite3_value_text(v);
+        const char *sw = s ? skip_ws(s) : "";
+        if (*sw == '[') { okey_append(&b, &n, &cap, "2", 1); okey_encode_list(db, s, &b, &n, &cap); }
+        else if (*sw == '{') { okey_append(&b, &n, &cap, "1", 1); okey_append(&b, &n, &cap, s, strlen(s)); }
+        else if (sqlite3_value_subtype(v) == GQL_SUBTYPE_BOOLEAN && s) {
+            okey_append(&b, &n, &cap, strcmp(s, "true") == 0 ? "61" : "60", 2);
+        } else { okey_append(&b, &n, &cap, "5", 1); if (s) okey_append(&b, &n, &cap, s, strlen(s)); }
+    } else {
+        okey_append(&b, &n, &cap, "9", 1);  /* unknown → sort last */
+    }
+    if (!b) { b = malloc(1); if (b) b[0] = '\0'; }
+    return b;
+}
+
+typedef struct { char *key; sqlite3_value *val; int have; } gql_minmax_acc;
+
+static void gql_minmax_step(sqlite3_context *context, int argc,
+                            sqlite3_value **argv, int is_max) {
+    if (argc != 1) return;
+    if (sqlite3_value_type(argv[0]) == SQLITE_NULL) return;  /* ignore nulls */
+    gql_minmax_acc *a = (gql_minmax_acc*)sqlite3_aggregate_context(context, sizeof(*a));
+    if (!a) return;
+    sqlite3 *db = sqlite3_context_db_handle(context);
+    char *k = okey_for_value(db, argv[0]);
+    if (!k) return;
+    if (!a->have) {
+        a->key = k; a->val = sqlite3_value_dup(argv[0]); a->have = 1;
+        return;
+    }
+    int cmp = strcmp(k, a->key);
+    bool better = is_max ? (cmp > 0) : (cmp < 0);
+    if (better) {
+        free(a->key); a->key = k;
+        sqlite3_value_free(a->val); a->val = sqlite3_value_dup(argv[0]);
+    } else {
+        free(k);
+    }
+}
+
+static void gql_minmax_final(sqlite3_context *context, int is_max) {
+    (void)is_max;
+    gql_minmax_acc *a = (gql_minmax_acc*)sqlite3_aggregate_context(context, 0);
+    if (!a || !a->have) { sqlite3_result_null(context); return; }
+    sqlite3_result_value(context, a->val);
+    free(a->key);
+    sqlite3_value_free(a->val);
+}
+
+void gql_min_step(sqlite3_context *c, int argc, sqlite3_value **argv) { gql_minmax_step(c, argc, argv, 0); }
+void gql_min_final(sqlite3_context *c) { gql_minmax_final(c, 0); }
+void gql_max_step(sqlite3_context *c, int argc, sqlite3_value **argv) { gql_minmax_step(c, argc, argv, 1); }
+void gql_max_final(sqlite3_context *c) { gql_minmax_final(c, 1); }
+
 /* Extract nanosecond portion from ISO datetime string.
  * Input forms: 'YYYY-MM-DDTHH:MM:SS.<digits><tz>?', returns digits zero-padded
  * to 9 places as integer. Returns 0 if no fractional second present. */

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -266,6 +266,100 @@ void gql_eq_func(
     else sqlite3_result_int(context, t == TVAL_TRUE ? 1 : 0);
 }
 
+/* Cypher ordered comparison of two values rendered as JSON-element text,
+ * with the element's json_type. Returns:
+ *   -1, 0, 1  ordinary comparison result
+ *   -2        undefined (null result — cross-type, null operand, or an
+ *             unorderable type such as a map/object reached during compare)
+ * Recurses into arrays element-wise per the Cypher list-ordering rules:
+ * compare pairwise; the first decisive element wins; if all compared
+ * elements are equal, the shorter list sorts first. A null/undefined
+ * element comparison propagates only once it is actually reached. */
+static int gql_cmp_json_vals(sqlite3 *db,
+                             const char *ja, const char *jta,
+                             const char *jb, const char *jtb);
+
+/* Compare two JSON array texts element-wise. */
+static int gql_cmp_json_arrays(sqlite3 *db, const char *aa, const char *ab) {
+    sqlite3_stmt *st = NULL;
+    int la = 0, lb = 0;
+    if (sqlite3_prepare_v2(db, "SELECT json_array_length(?1), json_array_length(?2)",
+                           -1, &st, NULL) != SQLITE_OK) return -2;
+    sqlite3_bind_text(st, 1, aa, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(st, 2, ab, -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(st) == SQLITE_ROW) {
+        la = sqlite3_column_int(st, 0);
+        lb = sqlite3_column_int(st, 1);
+    }
+    sqlite3_finalize(st);
+
+    int n = la < lb ? la : lb;
+    for (int i = 0; i < n; i++) {
+        char qa[96], qb[96];
+        snprintf(qa, sizeof(qa), "$[%d]", i);
+        snprintf(qb, sizeof(qb), "$[%d]", i);
+        sqlite3_stmt *es = NULL;
+        if (sqlite3_prepare_v2(db,
+                "SELECT json_extract(?1, ?3), json_type(?1, ?3), "
+                "json_extract(?2, ?4), json_type(?2, ?4)",
+                -1, &es, NULL) != SQLITE_OK) return -2;
+        sqlite3_bind_text(es, 1, aa, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(es, 2, ab, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(es, 3, qa, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(es, 4, qb, -1, SQLITE_TRANSIENT);
+        int c = -2;
+        if (sqlite3_step(es) == SQLITE_ROW) {
+            const char *va  = (const char*)sqlite3_column_text(es, 0);
+            const char *ta  = (const char*)sqlite3_column_text(es, 1);
+            const char *vb  = (const char*)sqlite3_column_text(es, 2);
+            const char *tb  = (const char*)sqlite3_column_text(es, 3);
+            /* For nested arrays, json_extract returns the sub-array text. */
+            char *va_dup = va ? strdup(va) : NULL;
+            char *ta_dup = ta ? strdup(ta) : NULL;
+            char *vb_dup = vb ? strdup(vb) : NULL;
+            char *tb_dup = tb ? strdup(tb) : NULL;
+            sqlite3_finalize(es);
+            c = gql_cmp_json_vals(db, va_dup, ta_dup, vb_dup, tb_dup);
+            free(va_dup); free(ta_dup); free(vb_dup); free(tb_dup);
+        } else {
+            sqlite3_finalize(es);
+        }
+        if (c != 0) return c;  /* decisive (or -2 undefined) */
+    }
+    /* All compared elements equal — shorter list sorts first. */
+    if (la == lb) return 0;
+    return la < lb ? -1 : 1;
+}
+
+static int gql_cmp_json_vals(sqlite3 *db,
+                             const char *ja, const char *jta,
+                             const char *jb, const char *jtb) {
+    if (!jta || !jtb) return -2;                  /* missing */
+    if (strcmp(jta, "null") == 0 || strcmp(jtb, "null") == 0) return -2;
+
+    bool a_num = (strcmp(jta, "integer") == 0 || strcmp(jta, "real") == 0);
+    bool b_num = (strcmp(jtb, "integer") == 0 || strcmp(jtb, "real") == 0);
+    if (a_num && b_num) {
+        double da = ja ? atof(ja) : 0.0, dbv = jb ? atof(jb) : 0.0;
+        return (da < dbv) ? -1 : (da > dbv) ? 1 : 0;
+    }
+    bool a_bool = (strcmp(jta, "true") == 0 || strcmp(jta, "false") == 0);
+    bool b_bool = (strcmp(jtb, "true") == 0 || strcmp(jtb, "false") == 0);
+    if (a_bool && b_bool) {
+        int ia = (strcmp(jta, "true") == 0), ib = (strcmp(jtb, "true") == 0);
+        return (ia < ib) ? -1 : (ia > ib) ? 1 : 0;
+    }
+    if (strcmp(jta, "text") == 0 && strcmp(jtb, "text") == 0) {
+        int c = strcmp(ja ? ja : "", jb ? jb : "");
+        return (c < 0) ? -1 : (c > 0) ? 1 : 0;
+    }
+    if (strcmp(jta, "array") == 0 && strcmp(jtb, "array") == 0) {
+        return gql_cmp_json_arrays(db, ja ? ja : "[]", jb ? jb : "[]");
+    }
+    /* Anything else (object/map/entity, or cross-type) is unorderable. */
+    return -2;
+}
+
 /* T-0308: Cypher ordering comparison with type-class check.
  *   _gql_order_cmp(left, right, op_str)
  *     op_str in {"<", ">", "<=", ">="}
@@ -311,21 +405,46 @@ void gql_order_cmp_func(
      * clearest cross-type case (list vs scalar, map vs scalar) and
      * matches what TCK Comparison2 [3] enforces. */
     bool l_json = false, r_json = false;
+    bool l_list = false, r_list = false, l_obj = false, r_obj = false;
     if (l_text) {
         const char *s = (const char *)sqlite3_value_text(argv[0]);
-        if (s && (s[0] == '[' || s[0] == '{')) l_json = true;
+        if (s && s[0] == '[') { l_json = true; l_list = true; }
+        else if (s && s[0] == '{') { l_json = true; l_obj = true; }
     }
     if (r_text) {
         const char *s = (const char *)sqlite3_value_text(argv[1]);
-        if (s && (s[0] == '[' || s[0] == '{')) r_json = true;
+        if (s && s[0] == '[') { r_json = true; r_list = true; }
+        else if (s && s[0] == '{') { r_json = true; r_obj = true; }
     }
     if (l_json != r_json) {
         /* container vs scalar — null per Cypher type lattice. */
         sqlite3_result_null(context); return;
     }
+    /* Maps / nodes / relationships / paths (JSON objects) have no ordering
+     * relation in Cypher — any ordered comparison involving one is null.
+     * (Comparison2 [3].) */
+    if (l_obj || r_obj) { sqlite3_result_null(context); return; }
 
     const char *op = (const char *)sqlite3_value_text(argv[2]);
     if (!op) { sqlite3_result_null(context); return; }
+
+    /* Two lists — element-wise comparison with null propagation and the
+     * shorter-prefix-sorts-first rule (Comparison2 [4]). */
+    if (l_list && r_list) {
+        sqlite3 *db = sqlite3_context_db_handle(context);
+        int c = gql_cmp_json_arrays(db,
+                    (const char *)sqlite3_value_text(argv[0]),
+                    (const char *)sqlite3_value_text(argv[1]));
+        if (c == -2) { sqlite3_result_null(context); return; }
+        bool result;
+        if      (strcmp(op, "<")  == 0) result = (c < 0);
+        else if (strcmp(op, ">")  == 0) result = (c > 0);
+        else if (strcmp(op, "<=") == 0) result = (c <= 0);
+        else if (strcmp(op, ">=") == 0) result = (c >= 0);
+        else { sqlite3_result_null(context); return; }
+        sqlite3_result_int(context, result ? 1 : 0);
+        return;
+    }
 
     int cmp = 0;
     if (l_num && r_num) {

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2638,29 +2638,16 @@ void gql_duration_parse_iso_func(sqlite3_context *ctx, int argc, sqlite3_value *
     double total_seconds_d = frac_days * 86400.0 + hours * 3600.0 + minutes * 60.0 + seconds;
     long long total_secs = (long long)total_seconds_d;
     double frac_secs = total_seconds_d - total_secs;
-    long long total_ns_from_secs = (long long)(frac_secs * 1e9 + 0.5);
+    /* Round half away from zero — the constant +0.5 truncated negative
+     * fractional seconds the wrong way (PT-1.999S → -1.998999999S). */
+    long long total_ns_from_secs = (long long)(frac_secs * 1e9 + (frac_secs >= 0 ? 0.5 : -0.5));
     long long total_ns = total_secs * 1000000000LL + total_ns_from_secs;
-    long long DAY_NS = 86400LL * 1000000000LL;
-    long long extra_days = total_ns / DAY_NS;
-    long long residue_ns = total_ns - extra_days * DAY_NS;
-    if (residue_ns < 0) { residue_ns += DAY_NS; extra_days -= 1; }
-    total_days += extra_days;
-
-    char iso[160];
-    format_iso_duration((int)total_months, (int)total_days, residue_ns, iso, sizeof(iso));
-    long long seconds_field, nanos_field;
-    if (residue_ns >= 0) {
-        seconds_field = residue_ns / 1000000000LL;
-        nanos_field = residue_ns - seconds_field * 1000000000LL;
-    } else {
-        seconds_field = -(((-residue_ns) + 999999999LL) / 1000000000LL);
-        nanos_field = residue_ns - seconds_field * 1000000000LL;
-    }
-    char json[512];
-    snprintf(json, sizeof(json),
-        "{\"_iso8601\":\"%s\",\"months\":%d,\"days\":%lld,\"seconds\":%lld,\"nanosecondsOfSecond\":%lld}",
-        iso, total_months, total_days, seconds_field, nanos_field);
-    sqlite3_result_text(ctx, json, -1, SQLITE_TRANSIENT);
+    /* Durations keep days and the sub-day time part as independent signed
+     * components — do NOT carry sub-day seconds into days (a day is not always
+     * 86400s, and PT-1.999S must stay a time duration, not -1 day + 23:59:58).
+     * emit_duration_json applies the same floor-normalization as the
+     * duration(map) path, so ISO round-trips equal the original. (Temporal6 [6].) */
+    emit_duration_json(ctx, total_months, total_days, total_ns);
     (void)inputs; (void)vals;
 }
 

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2955,9 +2955,10 @@ void gql_normalize_time_func(sqlite3_context *ctx, int argc, sqlite3_value **arg
                 if (strlen(tz_main + 1) >= 4) sscanf(tz_main + 1, "%2d%2d", &oh, &om);
                 else sscanf(tz_main + 1, "%d", &oh);
             }
-            snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d%s", tz_main[0], oh, om, bracket ? bracket : "");
-        } else if (*tz == '[') {
-            snprintf(tz_out, sizeof(tz_out), "%s", tz);
+            /* A `time` value carries only the numeric offset — the named-zone
+             * bracket (e.g. [Europe/Stockholm], already resolved to the offset)
+             * is dropped (only datetime keeps the zone name). Temporal3 [3]. */
+            snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d", tz_main[0], oh, om);
         }
     }
 

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -621,6 +621,40 @@ static void gql_entity_prop_lookup(sqlite3_context *context, int argc,
 void gql_node_prop_func(sqlite3_context *c, int argc, sqlite3_value **argv) {
     gql_entity_prop_lookup(c, argc, argv, false);
 }
+
+/* Static property access on a JSON value of unknown shape: `(expr).key`
+ * where expr yields a node/rel JSON object ({id,labels,properties}) OR a
+ * plain map. For a node/rel shape, regular keys live under $.properties and
+ * the meta keys (id/labels/type/startNode/endNode) at top level; a plain map
+ * uses top-level keys. (Graph6 [4]/[6]/[8].) argv[0]=value, argv[1]=key. */
+void gql_dyn_prop_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+    if (argc != 2) { sqlite3_result_null(context); return; }
+    if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
+        sqlite3_value_type(argv[1]) == SQLITE_NULL) { sqlite3_result_null(context); return; }
+    const char *v = (const char*)sqlite3_value_text(argv[0]);
+    if (!v) { sqlite3_result_null(context); return; }
+    const char *vw = skip_ws(v);
+    if (*vw != '{') { sqlite3_result_null(context); return; }  /* not a map/entity */
+    sqlite3 *db = sqlite3_context_db_handle(context);
+    sqlite3_stmt *st = NULL;
+    const char *sql =
+        "SELECT CASE WHEN json_type(?1, '$.properties') IS NOT NULL THEN "
+        "  CASE WHEN ?2 IN ('id','labels','type','startNode','endNode','start','end') "
+        "       THEN json_extract(?1, '$.' || ?2) "
+        "       ELSE json_extract(?1, '$.properties.' || ?2) END "
+        "ELSE json_extract(?1, '$.' || ?2) END";
+    if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) == SQLITE_OK) {
+        sqlite3_bind_value(st, 1, argv[0]);
+        sqlite3_bind_value(st, 2, argv[1]);
+        if (sqlite3_step(st) == SQLITE_ROW)
+            sqlite3_result_value(context, sqlite3_column_value(st, 0));
+        else
+            sqlite3_result_null(context);
+        sqlite3_finalize(st);
+    } else {
+        sqlite3_result_null(context);
+    }
+}
 void gql_edge_prop_func(sqlite3_context *c, int argc, sqlite3_value **argv) {
     gql_entity_prop_lookup(c, argc, argv, true);
 }

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -608,29 +608,63 @@ void gql_in_func(
         return;
     }
 
-    /* Build an "element = each element" comparison via json_each. */
+    /* Compare LHS against each collection element using Cypher 3VL equality
+     * (gql_eq_json), not raw SQL `=`. This gives correct results when an
+     * element is a list/map whose own elements include null (e.g.
+     * `[1,2] IN [[1,null]]` → null, `[1,null] IN [[1,null]]` → null). Aggregate
+     * per 3VL: any TRUE → true; else any NULL → null; else false.
+     * (List5 [21]/[29]/[31]/[34].) */
+    const char *lhs = (const char*)sqlite3_value_text(argv[0]);
+    if (!lhs) { sqlite3_result_null(context); return; }
+
     sqlite3 *db = sqlite3_context_db_handle(context);
     sqlite3_stmt *stmt = NULL;
     int rc = sqlite3_prepare_v2(db,
-        "SELECT "
-        "  MAX(CASE WHEN je.value IS NULL THEN 0 WHEN je.value = ?1 THEN 1 ELSE 0 END), "
-        "  MAX(CASE WHEN je.value IS NULL THEN 1 ELSE 0 END) "
-        "FROM json_each(?2) je",
-        -1, &stmt, NULL);
+        "SELECT je.value, je.type FROM json_each(?1) je", -1, &stmt, NULL);
     if (rc != SQLITE_OK) { sqlite3_result_null(context); return; }
-    sqlite3_bind_value(stmt, 1, argv[0]);
-    sqlite3_bind_text(stmt, 2, coll, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 1, coll, -1, SQLITE_TRANSIENT);
 
-    if (sqlite3_step(stmt) == SQLITE_ROW) {
-        int matched = sqlite3_column_int(stmt, 0);
-        int has_null = sqlite3_column_int(stmt, 1);
-        if (matched) sqlite3_result_int(context, 1);
-        else if (has_null) sqlite3_result_null(context);
-        else sqlite3_result_int(context, 0);
-    } else {
-        sqlite3_result_null(context);
+    const char *lhs_s = skip_ws(lhs);
+    bool lhs_container = (*lhs_s == '[' || *lhs_s == '{');
+
+    /* For scalar-vs-scalar comparison, replicate SQLite's typed `=` (the
+     * historical behavior: `1 = '1'` is false by storage class, booleans
+     * compare correctly) rather than gql_eq_json's text compare. */
+    sqlite3_stmt *cmp = NULL;
+    sqlite3_prepare_v2(db, "SELECT ?1 = ?2", -1, &cmp, NULL);
+
+    bool any_true = false, any_null = false;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *etype = (const char*)sqlite3_column_text(stmt, 1);
+        const char *eval  = (const char*)sqlite3_column_text(stmt, 0);
+        if ((etype && strcmp(etype, "null") == 0) || !eval) {
+            any_null = true;   /* comparing against null is indeterminate */
+            continue;
+        }
+        bool elem_container = etype && (strcmp(etype, "array") == 0 ||
+                                        strcmp(etype, "object") == 0);
+        tval t = TVAL_FALSE;
+        if (lhs_container || elem_container) {
+            /* Container on either side: gql_eq_json handles element-wise
+             * equality with null propagation and container-vs-scalar=false. */
+            t = gql_eq_json(lhs, eval);
+        } else if (cmp) {
+            /* Both scalars: typed SQLite equality on the original values. */
+            sqlite3_reset(cmp);
+            sqlite3_bind_value(cmp, 1, argv[0]);
+            sqlite3_bind_value(cmp, 2, sqlite3_column_value(stmt, 0));
+            if (sqlite3_step(cmp) == SQLITE_ROW)
+                t = sqlite3_column_int(cmp, 0) ? TVAL_TRUE : TVAL_FALSE;
+        }
+        if (t == TVAL_TRUE)  any_true = true;
+        else if (t == TVAL_NULL) any_null = true;
     }
+    if (cmp) sqlite3_finalize(cmp);
     sqlite3_finalize(stmt);
+
+    if (any_true)      sqlite3_result_int(context, 1);
+    else if (any_null) sqlite3_result_null(context);
+    else               sqlite3_result_int(context, 0);
 }
 
 /* Strict type-conversion UDFs. Each raises an SQL error (which the harness

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -583,6 +583,48 @@ void gql_subscript_func(
  *   x    IN coll        -> true if some element equals x, null if no match
  *                          but coll contains null, else false.
  * coll is provided as a JSON array text. */
+/* Dynamic property lookup on a node/edge by runtime key string, e.g.
+ * `n['nam' + 'e']` (Graph7 [1]-[3]). Static string keys are normalized to
+ * property access at transform time; a computed key needs this runtime
+ * EAV lookup. argv[0] = entity id, argv[1] = key text. */
+static void gql_entity_prop_lookup(sqlite3_context *context, int argc,
+                                   sqlite3_value **argv, bool is_edge) {
+    if (argc != 2) { sqlite3_result_null(context); return; }
+    if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
+        sqlite3_value_type(argv[1]) == SQLITE_NULL) { sqlite3_result_null(context); return; }
+    const char *col = is_edge ? "edge_id" : "node_id";
+    const char *pfx = is_edge ? "edge_props" : "node_props";
+    char sql[1024];
+    snprintf(sql, sizeof(sql),
+        "SELECT COALESCE("
+        "(SELECT value FROM %s_int t JOIN property_keys pk ON t.key_id=pk.id WHERE t.%s=?1 AND pk.key=?2),"
+        "(SELECT value FROM %s_real t JOIN property_keys pk ON t.key_id=pk.id WHERE t.%s=?1 AND pk.key=?2),"
+        "(SELECT value FROM %s_text t JOIN property_keys pk ON t.key_id=pk.id WHERE t.%s=?1 AND pk.key=?2),"
+        "(SELECT CASE WHEN value THEN 'true' ELSE 'false' END FROM %s_bool t JOIN property_keys pk ON t.key_id=pk.id WHERE t.%s=?1 AND pk.key=?2),"
+        "(SELECT json(value) FROM %s_json t JOIN property_keys pk ON t.key_id=pk.id WHERE t.%s=?1 AND pk.key=?2))",
+        pfx, col, pfx, col, pfx, col, pfx, col, pfx, col);
+    sqlite3 *db = sqlite3_context_db_handle(context);
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) == SQLITE_OK) {
+        sqlite3_bind_value(st, 1, argv[0]);
+        sqlite3_bind_value(st, 2, argv[1]);
+        if (sqlite3_step(st) == SQLITE_ROW)
+            sqlite3_result_value(context, sqlite3_column_value(st, 0));
+        else
+            sqlite3_result_null(context);
+        sqlite3_finalize(st);
+    } else {
+        sqlite3_result_null(context);
+    }
+}
+
+void gql_node_prop_func(sqlite3_context *c, int argc, sqlite3_value **argv) {
+    gql_entity_prop_lookup(c, argc, argv, false);
+}
+void gql_edge_prop_func(sqlite3_context *c, int argc, sqlite3_value **argv) {
+    gql_entity_prop_lookup(c, argc, argv, true);
+}
+
 void gql_in_func(
     sqlite3_context *context,
     int argc,

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -340,17 +340,32 @@ void gql_order_cmp_func(
         if (cmp < 0) cmp = -1;
         else if (cmp > 0) cmp = 1;
     } else {
-        /* Mixed scalar text<->numeric — preserve SQLite native behavior
-         * for now. Pre-T-0308 codepath returned a value (numeric < text
-         * was always true in SQLite); tests like WithWhere5 rely on
-         * this comparison succeeding rather than returning null. */
-        if (l_num && r_text) {
-            cmp = -1;
-        } else if (l_text && r_num) {
-            cmp = 1;
-        } else {
+        /* T-0331: Cross-type ordered comparison returns null per the
+         * Cypher spec (Comparison2 [3], [6]).
+         *
+         * Exception: graphqlite sometimes flows boolean values as the
+         * text 'true'/'false' (no boolean subtype on this value path).
+         * Precedence1 [23]/[26] rely on those still ordering against
+         * numeric-encoded booleans. Treat stringified booleans as 1/0
+         * and let the comparison proceed numerically; otherwise null. */
+        double la = 0.0, lb = 0.0;
+        bool l_resolved = false, r_resolved = false;
+        if (l_num) { la = sqlite3_value_double(argv[0]); l_resolved = true; }
+        else if (l_text) {
+            const char *s = (const char *)sqlite3_value_text(argv[0]);
+            if (s && strcmp(s, "true") == 0)  { la = 1.0; l_resolved = true; }
+            else if (s && strcmp(s, "false") == 0) { la = 0.0; l_resolved = true; }
+        }
+        if (r_num) { lb = sqlite3_value_double(argv[1]); r_resolved = true; }
+        else if (r_text) {
+            const char *s = (const char *)sqlite3_value_text(argv[1]);
+            if (s && strcmp(s, "true") == 0)  { lb = 1.0; r_resolved = true; }
+            else if (s && strcmp(s, "false") == 0) { lb = 0.0; r_resolved = true; }
+        }
+        if (!l_resolved || !r_resolved) {
             sqlite3_result_null(context); return;
         }
+        cmp = (la < lb) ? -1 : (la > lb) ? 1 : 0;
     }
 
     bool result;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2675,6 +2675,44 @@ void gql_duration_parse_iso_func(sqlite3_context *ctx, int argc, sqlite3_value *
  *
  * Returns NULL on parse failure or unknown field.
  */
+/* Duration component accessors (Temporal5 [7]). All derive from the normalized
+ * {months, days, seconds, nanosecondsOfSecond}. argv[0]=duration JSON,
+ * argv[1]=field. */
+void gql_duration_field_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    if (argc != 2 || sqlite3_value_type(argv[0]) == SQLITE_NULL ||
+        sqlite3_value_type(argv[1]) == SQLITE_NULL) { sqlite3_result_null(ctx); return; }
+    const char *j = (const char*)sqlite3_value_text(argv[0]);
+    const char *f = (const char*)sqlite3_value_text(argv[1]);
+    if (!j || !f) { sqlite3_result_null(ctx); return; }
+    long long m  = dur_field_ll(j, "months");
+    long long da = dur_field_ll(j, "days");
+    long long s  = dur_field_ll(j, "seconds");
+    long long ns = dur_field_ll(j, "nanosecondsOfSecond");
+    long long r;
+    if      (!strcmp(f, "years"))                r = m / 12;
+    else if (!strcmp(f, "quarters"))             r = m / 3;
+    else if (!strcmp(f, "months"))               r = m;
+    else if (!strcmp(f, "monthsOfYear"))         r = m % 12;
+    else if (!strcmp(f, "monthsOfQuarter"))      r = m % 3;
+    else if (!strcmp(f, "quartersOfYear"))       r = (m / 3) % 4;
+    else if (!strcmp(f, "weeks"))                r = da / 7;
+    else if (!strcmp(f, "days"))                 r = da;
+    else if (!strcmp(f, "daysOfWeek"))           r = da % 7;
+    else if (!strcmp(f, "hours"))                r = s / 3600;
+    else if (!strcmp(f, "minutes"))              r = s / 60;
+    else if (!strcmp(f, "minutesOfHour"))        r = (s / 60) % 60;
+    else if (!strcmp(f, "seconds"))              r = s;
+    else if (!strcmp(f, "secondsOfMinute"))      r = s % 60;
+    else if (!strcmp(f, "milliseconds"))         r = s * 1000LL + ns / 1000000LL;
+    else if (!strcmp(f, "millisecondsOfSecond")) r = ns / 1000000LL;
+    else if (!strcmp(f, "microseconds"))         r = s * 1000000LL + ns / 1000LL;
+    else if (!strcmp(f, "microsecondsOfSecond")) r = ns / 1000LL;
+    else if (!strcmp(f, "nanoseconds"))          r = s * 1000000000LL + ns;
+    else if (!strcmp(f, "nanosecondsOfSecond"))  r = ns;
+    else { sqlite3_result_null(ctx); return; }
+    sqlite3_result_int64(ctx, r);
+}
+
 void gql_temporal_field_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
     if (argc != 2) { sqlite3_result_null(ctx); return; }
     const char *s = (const char*)sqlite3_value_text(argv[0]);
@@ -2756,6 +2794,7 @@ void gql_temporal_field_func(sqlite3_context *ctx, int argc, sqlite3_value **arg
     }
     if (p.has_tz) {
         if (strcmp(field, "offsetMinutes") == 0) { sqlite3_result_int(ctx, p.tz_offset_min); return; }
+        if (strcmp(field, "offsetSeconds") == 0) { sqlite3_result_int(ctx, p.tz_offset_min * 60); return; }
         if (strcmp(field, "offset") == 0 || strcmp(field, "timezone") == 0) {
             char buf[16];
             int oh = p.tz_offset_min / 60;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -921,6 +921,72 @@ static int parse_tz(const char *p, int *consumed) {
     return sign * (hh*60 + mm);
 }
 
+/* --- Order-preserving sort-key encoding for JSON lists (WithOrderBy1
+ * [9]/[10]/[31]). Cypher orders lists element-wise, shorter-prefix first.
+ * SQLite ORDER BY needs a scalar key whose BINARY (byte) comparison matches
+ * that order, so we encode each list element into a token whose lexicographic
+ * byte order matches Cypher orderability. --- */
+static void okey_append(char **b, size_t *n, size_t *cap, const char *s, size_t slen) {
+    if (*n + slen + 1 > *cap) {
+        size_t nc = (*cap ? *cap : 64);
+        while (nc < *n + slen + 1) nc *= 2;
+        char *nb = realloc(*b, nc);
+        if (!nb) return;
+        *b = nb; *cap = nc;
+    }
+    memcpy(*b + *n, s, slen); *n += slen; (*b)[*n] = '\0';
+}
+
+/* IEEE-754 order-preserving transform: map a double to a uint64 whose
+ * unsigned order matches numeric order, then emit as fixed-width hex. */
+static void okey_num(char **b, size_t *n, size_t *cap, double d) {
+    uint64_t bits; memcpy(&bits, &d, sizeof(bits));
+    if (bits & 0x8000000000000000ULL) bits = ~bits;      /* negative */
+    else bits |= 0x8000000000000000ULL;                  /* positive */
+    char hex[20];
+    snprintf(hex, sizeof(hex), "%016llX", (unsigned long long)bits);
+    okey_append(b, n, cap, hex, 16);
+}
+
+static void okey_encode_list(sqlite3 *db, const char *json,
+                             char **b, size_t *n, size_t *cap) {
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db, "SELECT value, type FROM json_each(?1)",
+                           -1, &st, NULL) != SQLITE_OK) return;
+    sqlite3_bind_text(st, 1, json, -1, SQLITE_TRANSIENT);
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        okey_append(b, n, cap, "\x02", 1);   /* element marker (> terminator) */
+        const char *type = (const char*)sqlite3_column_text(st, 1);
+        if (!type) { okey_append(b, n, cap, "9", 1); continue; }
+        /* Leading digit = cross-type group order; constant within a type so
+         * same-typed elements compare by their payload. Per Cypher
+         * orderability (ascending): map/object < list < string < boolean
+         * < number < null (WithOrderBy1 [9]/[10]). */
+        if (strcmp(type, "object") == 0) {
+            okey_append(b, n, cap, "1", 1);
+            const char *sub = (const char*)sqlite3_column_text(st, 0);
+            okey_append(b, n, cap, sub ? sub : "{}", sub ? strlen(sub) : 2);
+        } else if (strcmp(type, "array") == 0) {
+            okey_append(b, n, cap, "2", 1);
+            const char *sub = (const char*)sqlite3_column_text(st, 0);
+            okey_encode_list(db, sub ? sub : "[]", b, n, cap);
+        } else if (strcmp(type, "text") == 0) {
+            okey_append(b, n, cap, "5", 1);
+            const char *tv = (const char*)sqlite3_column_text(st, 0);
+            okey_append(b, n, cap, tv ? tv : "", tv ? strlen(tv) : 0);
+        } else if (strcmp(type, "true") == 0 || strcmp(type, "false") == 0) {
+            okey_append(b, n, cap, strcmp(type, "true") == 0 ? "6T" : "6F", 2);
+        } else if (strcmp(type, "integer") == 0 || strcmp(type, "real") == 0) {
+            okey_append(b, n, cap, "7", 1);
+            okey_num(b, n, cap, sqlite3_column_double(st, 0));
+        } else { /* null sorts last */
+            okey_append(b, n, cap, "9", 1);
+        }
+    }
+    sqlite3_finalize(st);
+    okey_append(b, n, cap, "\x01", 1);   /* terminator (< element marker) */
+}
+
 void gql_order_key_func(
     sqlite3_context *context,
     int argc,
@@ -934,6 +1000,19 @@ void gql_order_key_func(
     }
     const char *s = (const char*)sqlite3_value_text(argv[0]);
     if (!s) { sqlite3_result_null(context); return; }
+
+    /* JSON list → order-preserving element-wise key. */
+    if (s[0] == '[') {
+        char *buf = NULL; size_t n = 0, cap = 0;
+        okey_encode_list(sqlite3_context_db_handle(context), s, &buf, &n, &cap);
+        if (buf) {
+            sqlite3_result_text(context, buf, (int)n, SQLITE_TRANSIENT);
+            free(buf);
+        } else {
+            sqlite3_result_value(context, argv[0]);
+        }
+        return;
+    }
 
     size_t slen = strlen(s);
 

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -92,6 +92,9 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
   rc = sqlite3_create_function(db, "_gql_edge_prop", 2,
                          SQLITE_UTF8, 0, gql_edge_prop_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
+  rc = sqlite3_create_function(db, "_gql_dyn_prop", 2,
+                         SQLITE_UTF8, 0, gql_dyn_prop_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
 
   /* Cypher-orderability min()/max() aggregates (step + final, no scalar fn). */
   rc = sqlite3_create_function(db, "_gql_min", 1,

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -151,6 +151,9 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
                          gql_duration_parse_iso_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
 
+  rc = sqlite3_create_function(db, "_gql_duration_field", 2, SQLITE_UTF8, 0,
+                         gql_duration_field_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
   rc = sqlite3_create_function(db, "_gql_temporal_field", 2, SQLITE_UTF8, 0,
                          gql_temporal_field_func, 0, 0);
   if (rc != SQLITE_OK) return rc;

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -85,6 +85,14 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
                          gql_in_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
 
+  /* Dynamic property lookup by runtime key (Graph7 n['na'+'me']). */
+  rc = sqlite3_create_function(db, "_gql_node_prop", 2,
+                         SQLITE_UTF8, 0, gql_node_prop_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
+  rc = sqlite3_create_function(db, "_gql_edge_prop", 2,
+                         SQLITE_UTF8, 0, gql_edge_prop_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
+
   /* Cypher-orderability min()/max() aggregates (step + final, no scalar fn). */
   rc = sqlite3_create_function(db, "_gql_min", 1,
                          SQLITE_UTF8, 0,

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -85,6 +85,17 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
                          gql_in_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
 
+  /* Cypher-orderability min()/max() aggregates (step + final, no scalar fn). */
+  rc = sqlite3_create_function(db, "_gql_min", 1,
+                         SQLITE_UTF8, 0,
+                         0, gql_min_step, gql_min_final);
+  if (rc != SQLITE_OK) return rc;
+
+  rc = sqlite3_create_function(db, "_gql_max", 1,
+                         SQLITE_UTF8, 0,
+                         0, gql_max_step, gql_max_final);
+  if (rc != SQLITE_OK) return rc;
+
   rc = sqlite3_create_function(db, "_gql_subscript", 2,
                          SQLITE_UTF8 | SQLITE_DETERMINISTIC, 0,
                          gql_subscript_func, 0, 0);

--- a/src/backend/transform/cypher_transform.c
+++ b/src/backend/transform/cypher_transform.c
@@ -1207,16 +1207,21 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
      * each node maps to itself with depth=0. */
     if (min_hops == 0) {
         dbuf_appendf(&cte_query,
-            "SELECT n.id, n.id, 0, CAST(n.id AS TEXT), ',' || n.id || ',' "
+            "SELECT n.id, n.id, 0, CAST(n.id AS TEXT), ',' || n.id || ',', "
+            "CAST(n.id AS TEXT) "
             "FROM nodes n UNION ALL ");
     }
 
-    /* Base case: direct edges (depth = 1) */
+    /* Base case: direct edges (depth = 1).
+     * elem_ids carries the FULL interleaved path: node,edge,node,...
+     * (path_ids stays node-only for existing consumers). */
     dbuf_appendf(&cte_query,
         "SELECT e.%s, e.%s, 1, "
         "CAST(e.%s || ',' || e.%s AS TEXT), "
-        "','|| e.%s || ',' || e.%s || ','  "
+        "','|| e.%s || ',' || e.%s || ',', "
+        "e.%s || ',' || e.id || ',' || e.%s "
         "FROM edges e",
+        src_col, tgt_col,
         src_col, tgt_col,
         src_col, tgt_col,
         src_col, tgt_col);
@@ -1247,11 +1252,12 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
     dbuf_appendf(&cte_query,
         "SELECT cte.start_id, e.%s, cte.depth + 1, "
         "cte.path_ids || ',' || e.%s, "
-        "cte.visited || e.%s || ',' "
+        "cte.visited || e.%s || ',', "
+        "cte.elem_ids || ',' || e.id || ',' || e.%s "
         "FROM %s cte "
         "JOIN edges e ON e.%s = cte.end_id "
         "WHERE cte.depth >= 1 AND cte.depth < %d",
-        tgt_col, tgt_col, tgt_col,
+        tgt_col, tgt_col, tgt_col, tgt_col,
         cte_name,
         src_col,
         max_hops);
@@ -1283,7 +1289,7 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
     /* Build CTE name with column definitions */
     char cte_full_name[256];
     snprintf(cte_full_name, sizeof(cte_full_name),
-             "%s(start_id, end_id, depth, path_ids, visited)", cte_name);
+             "%s(start_id, end_id, depth, path_ids, visited, elem_ids)", cte_name);
 
     /* Add CTE to unified builder - recursive CTE */
     sql_cte(ctx->unified_builder, cte_full_name, dbuf_get(&cte_query), true);

--- a/src/backend/transform/transform_expr_ops.c
+++ b/src/backend/transform/transform_expr_ops.c
@@ -675,10 +675,17 @@ int transform_property_access(cypher_transform_context *ctx, cypher_property *pr
         /* json_extract raises 'malformed JSON' on non-JSON inputs (e.g. a
          * temporal string like '1984-10-11'), so guard with json_valid. */
         { char *esc_prop = escape_sql_string(prop->property_name);
-          append_sql(ctx, "CASE WHEN json_valid(%s) THEN json_extract(%s, '$.%s')"
-                          " ELSE _gql_temporal_field(%s, '%s') END",
-                     alias, alias, esc_prop ? esc_prop : prop->property_name,
-                     alias, esc_prop ? esc_prop : prop->property_name);
+          const char *pn = esc_prop ? esc_prop : prop->property_name;
+          /* Duration JSON (carries an "_iso8601" key) → derived-component
+           * accessor; other JSON → json_extract; temporal string → field
+           * parser. (Temporal5 [7].) */
+          append_sql(ctx,
+              "CASE WHEN json_valid(%s) AND instr(%s, '\"_iso8601\"') > 0 THEN _gql_duration_field(%s, '%s')"
+              " WHEN json_valid(%s) THEN json_extract(%s, '$.%s')"
+              " ELSE _gql_temporal_field(%s, '%s') END",
+              alias, alias, alias, pn,
+              alias, alias, pn,
+              alias, pn);
           free(esc_prop); }
         return 0;
     }

--- a/src/backend/transform/transform_expr_ops.c
+++ b/src/backend/transform/transform_expr_ops.c
@@ -557,15 +557,19 @@ int transform_property_access(cypher_transform_context *ctx, cypher_property *pr
         return 0;
     }
 
-    /* Handle subscript base: list[0].name → json_extract(list_subscript_sql, '$.name') */
+    /* Handle subscript base: (list[0]).name. The subscript may yield a plain
+     * map OR a node/relationship JSON object (e.g. `WITH [123, n] AS list
+     * RETURN (list[1]).existing`), so route through _gql_dyn_prop which picks
+     * $.properties.<key> for entity-shaped objects and $.<key> for maps.
+     * (Graph6 [4]/[6]/[8].) */
     if (prop->expr->type == AST_NODE_SUBSCRIPT) {
-        append_sql(ctx, "json_extract(");
+        append_sql(ctx, "_gql_dyn_prop(");
         if (transform_expression(ctx, prop->expr) < 0) return -1;
-        append_sql(ctx, ", '$.");
+        append_sql(ctx, ", ");
         { char *esc_prop = escape_sql_string(prop->property_name);
-          append_sql(ctx, "%s", esc_prop ? esc_prop : prop->property_name);
+          append_sql(ctx, "'%s'", esc_prop ? esc_prop : prop->property_name);
           free(esc_prop); }
-        append_sql(ctx, "')");
+        append_sql(ctx, ")");
         return 0;
     }
 

--- a/src/backend/transform/transform_expr_ops.c
+++ b/src/backend/transform/transform_expr_ops.c
@@ -42,13 +42,30 @@ int transform_label_expression(cypher_transform_context *ctx, cypher_label_expr 
         ctx->error_message = strdup(error);
         return -1;
     }
-    
-    /* Generate SQL to check if the node has the specified label */
-    /* This checks if there's a record in node_labels table with this node_id and label */
-    append_sql(ctx, "EXISTS (SELECT 1 FROM node_labels WHERE node_id = %s.id AND label = ", alias);
-    append_string_literal(ctx, label_expr->label_name);
-    append_sql(ctx, ")");
-    
+
+    /* Determine the entity's id reference. For post-WITH / projected vars the
+     * alias IS the id; for a fresh MATCH node/edge it is alias.id. */
+    transform_var *var = transform_var_lookup(ctx->var_ctx, id->name);
+    bool is_edge = var && var->kind == VAR_KIND_EDGE;
+    bool alias_is_id = transform_var_alias_is_id(ctx->var_ctx, id->name) ||
+                       (var && var->kind == VAR_KIND_PROJECTED);
+    char idref[256];
+    snprintf(idref, sizeof(idref), "%s%s", alias, alias_is_id ? "" : ".id");
+
+    /* Label/type predicate with Cypher 3VL: a null entity yields null, not
+     * false (Graph5 [5]); on a relationship `r:T` checks the edge TYPE, not
+     * node labels (Graph5 [2]). */
+    append_sql(ctx, "(CASE WHEN %s IS NULL THEN NULL WHEN ", idref);
+    if (is_edge) {
+        append_sql(ctx, "(SELECT type FROM edges WHERE id = %s) = ", idref);
+        append_string_literal(ctx, label_expr->label_name);
+    } else {
+        append_sql(ctx, "EXISTS (SELECT 1 FROM node_labels WHERE node_id = %s AND label = ", idref);
+        append_string_literal(ctx, label_expr->label_name);
+        append_sql(ctx, ")");
+    }
+    append_sql(ctx, " THEN 1 ELSE 0 END)");
+
     return 0;
 }
 

--- a/src/backend/transform/transform_expr_predicate.c
+++ b/src/backend/transform/transform_expr_predicate.c
@@ -293,8 +293,17 @@ int transform_list_predicate(cypher_transform_context *ctx, cypher_list_predicat
     const char *old_alias = transform_var_get_alias(ctx->var_ctx, pred->variable);
     char *saved_alias = old_alias ? strdup(old_alias) : NULL;
 
-    /* Register the predicate variable to map to json_each.value */
-    transform_var_register_projected(ctx->var_ctx, pred->variable, "json_each.value");
+    /* Give this level's json_each a unique alias so nested quantifiers
+     * (e.g. single(x IN ... WHERE none(y IN x ...))) don't shadow each
+     * other — the inner json_each must not capture the outer iteration
+     * variable. Map the predicate variable to "<alias>.value".
+     * (Quantifier6 family.) */
+    char je_alias[32], je_value[40];
+    snprintf(je_alias, sizeof(je_alias), "_je_%d", ctx->quantifier_counter++);
+    snprintf(je_value, sizeof(je_value), "%s.value", je_alias);
+
+    /* Register the predicate variable to map to <alias>.value */
+    transform_var_register_projected(ctx->var_ctx, pred->variable, je_value);
 
     /* `all` keeps the legacy "no FALSE → TRUE, ignore NULL" semantics. The
      * openCypher TCK has an internal conflict here: Quantifier4 [10] expects
@@ -310,7 +319,7 @@ int transform_list_predicate(cypher_transform_context *ctx, cypher_list_predicat
             if (saved_alias) free(saved_alias);
             return -1;
         }
-        append_sql(ctx, ") WHERE NOT (");
+        append_sql(ctx, ") AS %s WHERE NOT (", je_alias);
         if (transform_expression(ctx, pred->predicate) < 0) {
             if (saved_alias) free(saved_alias);
             return -1;
@@ -354,7 +363,7 @@ int transform_list_predicate(cypher_transform_context *ctx, cypher_list_predicat
             if (saved_alias) free(saved_alias);
             return -1;
         }
-        append_sql(ctx, ")))");
+        append_sql(ctx, ") AS %s))", je_alias);
     }
 
     /* Restore the old alias if we saved one */

--- a/src/backend/transform/transform_expr_predicate.c
+++ b/src/backend/transform/transform_expr_predicate.c
@@ -305,29 +305,22 @@ int transform_list_predicate(cypher_transform_context *ctx, cypher_list_predicat
     /* Register the predicate variable to map to <alias>.value */
     transform_var_register_projected(ctx->var_ctx, pred->variable, je_value);
 
-    /* `all` keeps the legacy "no FALSE → TRUE, ignore NULL" semantics. The
-     * openCypher TCK has an internal conflict here: Quantifier4 [10] expects
-     * strict 3VL for `all`, but Precedence1 [14]–[28] iterate (true,false,null)
-     * and use `all(x IN eq WHERE x)` where eq has TRUE+NULL elements and the
-     * scenarios expect TRUE. The Precedence1 cluster (~35 scenarios) outweighs
-     * the Quantifier4 [10] NULL examples (~4) so we keep the legacy form for
-     * ALL. NONE / ANY / SINGLE use strict 3VL — they have no analogous conflict
-     * and Quantifier1/2/3 [10] scenarios require it. */
-    if (pred->pred_type == LIST_PRED_ALL) {
-        append_sql(ctx, "(NOT EXISTS (SELECT 1 FROM json_each(");
-        if (transform_expression(ctx, pred->list_expr) < 0) {
-            if (saved_alias) free(saved_alias);
-            return -1;
-        }
-        append_sql(ctx, ") AS %s WHERE NOT (", je_alias);
-        if (transform_expression(ctx, pred->predicate) < 0) {
-            if (saved_alias) free(saved_alias);
-            return -1;
-        }
-        append_sql(ctx, ")))");
-    } else {
+    /* all/any/none/single all use strict openCypher 3VL via the SUM-over-
+     * json_each CASE below. (An earlier note claimed `all` had to keep a
+     * legacy "ignore NULL → TRUE" form to satisfy Precedence1 [14]–[28];
+     * that conflict no longer exists — Precedence1 stays 55/55 under strict
+     * 3VL, and strict 3VL fixes Quantifier4 [10].) */
+    {
         append_sql(ctx, "(SELECT CASE ");
         switch (pred->pred_type) {
+            case LIST_PRED_ALL:
+                /* F>0 → FALSE ; N>0 → NULL ; else TRUE (strict 3VL,
+                 * Quantifier4 [10]). */
+                append_sql(ctx,
+                    "WHEN SUM(CASE WHEN p IS NOT NULL AND NOT p THEN 1 ELSE 0 END) > 0 THEN 0 "
+                    "WHEN SUM(CASE WHEN p IS NULL THEN 1 ELSE 0 END) > 0 THEN NULL "
+                    "ELSE 1 ");
+                break;
             case LIST_PRED_ANY:
                 /* T>0 → TRUE ; N>0 → NULL ; else FALSE */
                 append_sql(ctx,

--- a/src/backend/transform/transform_func_aggregate.c
+++ b/src/backend/transform/transform_func_aggregate.c
@@ -106,12 +106,23 @@ int transform_aggregate_function(cypher_transform_context *ctx, cypher_function_
         return transform_aggregate_with_property(ctx, func_call, prop);
     }
 
-    /* Generate SQL function call - convert to uppercase for SQL compliance */
+    /* min()/max() use Cypher orderability (object < list < text < bool <
+     * number < null), not SQLite's storage-class MIN/MAX — route to the
+     * custom aggregates _gql_min / _gql_max (Aggregation2 [9]/[11]/[12]). */
+    const char *fn = func_call->function_name;
+    bool is_min = (strcasecmp(fn, "min") == 0);
+    bool is_max = (strcasecmp(fn, "max") == 0);
+
     char upper_func[64];
-    strncpy(upper_func, func_call->function_name, sizeof(upper_func) - 1);
-    upper_func[sizeof(upper_func) - 1] = '\0';
-    for (int i = 0; upper_func[i]; i++) {
-        upper_func[i] = toupper(upper_func[i]);
+    if (is_min || is_max) {
+        snprintf(upper_func, sizeof(upper_func), is_min ? "_gql_min" : "_gql_max");
+    } else {
+        /* Generate SQL function call - convert to uppercase for SQL compliance */
+        strncpy(upper_func, func_call->function_name, sizeof(upper_func) - 1);
+        upper_func[sizeof(upper_func) - 1] = '\0';
+        for (int i = 0; upper_func[i]; i++) {
+            upper_func[i] = toupper(upper_func[i]);
+        }
     }
 
     if (func_call->distinct) {

--- a/src/backend/transform/transform_func_path.c
+++ b/src/backend/transform/transform_func_path.c
@@ -172,24 +172,33 @@ int transform_path_relationships_function(cypher_transform_context *ctx, cypher_
         return -1;
     }
 
-    /* Build JSON array of relationship IDs */
-    append_sql(ctx, "json_array(");
-    bool first = true;
-    for (int i = 0; i < path_var->path_elements->count; i++) {
+    /* Collect relationship aliases in path order. */
+    const char *rel_aliases[64];
+    int n_rels = 0;
+    for (int i = 0; i < path_var->path_elements->count && n_rels < 64; i++) {
         ast_node *element = path_var->path_elements->items[i];
         if (element->type == AST_NODE_REL_PATTERN) {
             cypher_rel_pattern *rel = (cypher_rel_pattern*)element;
             if (rel->variable) {
                 const char *rel_alias = transform_var_get_alias(ctx->var_ctx, rel->variable);
-                if (rel_alias) {
-                    if (!first) append_sql(ctx, ", ");
-                    append_sql(ctx, "%s.id", rel_alias);
-                    first = false;
-                }
+                if (rel_alias) rel_aliases[n_rels++] = rel_alias;
             }
         }
     }
-    append_sql(ctx, ")");
+
+    /* relationships() on a null path (e.g. an OPTIONAL pattern that didn't
+     * match) is null, not [null]. Guard on the first rel alias's id being
+     * NULL — an OPTIONAL path matches all-or-nothing. (Path2 [3].) */
+    if (n_rels > 0) {
+        append_sql(ctx, "(CASE WHEN %s.id IS NULL THEN NULL ELSE json_array(", rel_aliases[0]);
+        for (int i = 0; i < n_rels; i++) {
+            if (i > 0) append_sql(ctx, ", ");
+            append_sql(ctx, "%s.id", rel_aliases[i]);
+        }
+        append_sql(ctx, ") END)");
+    } else {
+        append_sql(ctx, "json_array()");
+    }
 
     return 0;
 }

--- a/src/backend/transform/transform_func_path.c
+++ b/src/backend/transform/transform_func_path.c
@@ -180,6 +180,41 @@ int transform_path_relationships_function(cypher_transform_context *ctx, cypher_
         return -1;
     }
 
+    /* Variable-length rel in the path: its edge ids live in the varlen CTE's
+     * interleaved elem_ids (node,edge,node,... — edges at odd positions), not
+     * in a single `.id` column. Build the rel-id list from there.
+     * (Path2 [1]/[2].) */
+    for (int i = 0; i < path_var->path_elements->count; i++) {
+        ast_node *element = path_var->path_elements->items[i];
+        if (element->type == AST_NODE_REL_PATTERN &&
+            ((cypher_rel_pattern*)element)->varlen) {
+            cypher_rel_pattern *rel = (cypher_rel_pattern*)element;
+            const char *alias = rel->variable ?
+                transform_var_get_alias(ctx->var_ctx, rel->variable) : NULL;
+            if (alias) {
+                append_sql(ctx,
+                    "(SELECT json_group_array(json_object("
+                    "'id', e.id, 'type', e.type, 'startNode', e.source_id, 'endNode', e.target_id, "
+                    "'properties', COALESCE((SELECT json_group_object(pk.key, COALESCE("
+                      "(SELECT ept.value FROM edge_props_text ept WHERE ept.edge_id = e.id AND ept.key_id = pk.id), "
+                      "(SELECT epi.value FROM edge_props_int epi WHERE epi.edge_id = e.id AND epi.key_id = pk.id), "
+                      "(SELECT epr.value FROM edge_props_real epr WHERE epr.edge_id = e.id AND epr.key_id = pk.id), "
+                      "(SELECT json(CASE WHEN epb.value THEN 'true' ELSE 'false' END) FROM edge_props_bool epb WHERE epb.edge_id = e.id AND epb.key_id = pk.id), "
+                      "(SELECT json(epj.value) FROM edge_props_json epj WHERE epj.edge_id = e.id AND epj.key_id = pk.id))) "
+                      "FROM property_keys pk WHERE "
+                        "EXISTS (SELECT 1 FROM edge_props_text WHERE edge_id = e.id AND key_id = pk.id) OR "
+                        "EXISTS (SELECT 1 FROM edge_props_int WHERE edge_id = e.id AND key_id = pk.id) OR "
+                        "EXISTS (SELECT 1 FROM edge_props_real WHERE edge_id = e.id AND key_id = pk.id) OR "
+                        "EXISTS (SELECT 1 FROM edge_props_bool WHERE edge_id = e.id AND key_id = pk.id) OR "
+                        "EXISTS (SELECT 1 FROM edge_props_json WHERE edge_id = e.id AND key_id = pk.id)"
+                      "), json('{}'))) ORDER BY je.key) "
+                    "FROM json_each('[' || %s.elem_ids || ']') je JOIN edges e ON e.id = je.value "
+                    "WHERE (je.key %% 2) = 1)", alias);
+                return 0;
+            }
+        }
+    }
+
     /* Collect relationship aliases in path order. */
     const char *rel_aliases[64];
     int n_rels = 0;

--- a/src/backend/transform/transform_func_path.c
+++ b/src/backend/transform/transform_func_path.c
@@ -100,24 +100,32 @@ int transform_path_nodes_function(cypher_transform_context *ctx, cypher_function
         return -1;
     }
 
-    /* Build JSON array of node IDs */
-    append_sql(ctx, "json_array(");
-    bool first = true;
-    for (int i = 0; i < path_var->path_elements->count; i++) {
+    /* Collect node aliases in path order. */
+    const char *node_aliases[64];
+    int n_nodes = 0;
+    for (int i = 0; i < path_var->path_elements->count && n_nodes < 64; i++) {
         ast_node *element = path_var->path_elements->items[i];
         if (element->type == AST_NODE_NODE_PATTERN) {
             cypher_node_pattern *node = (cypher_node_pattern*)element;
             if (node->variable) {
                 const char *node_alias = transform_var_get_alias(ctx->var_ctx, node->variable);
-                if (node_alias) {
-                    if (!first) append_sql(ctx, ", ");
-                    append_sql(ctx, "%s.id", node_alias);
-                    first = false;
-                }
+                if (node_alias) node_aliases[n_nodes++] = node_alias;
             }
         }
     }
-    append_sql(ctx, ")");
+
+    /* nodes() on a null path (OPTIONAL pattern that didn't match) is null,
+     * not [null,...]. Guard on the first node alias's id (all-or-nothing). */
+    if (n_nodes > 0) {
+        append_sql(ctx, "(CASE WHEN %s.id IS NULL THEN NULL ELSE json_array(", node_aliases[0]);
+        for (int i = 0; i < n_nodes; i++) {
+            if (i > 0) append_sql(ctx, ", ");
+            append_sql(ctx, "%s.id", node_aliases[i]);
+        }
+        append_sql(ctx, ") END)");
+    } else {
+        append_sql(ctx, "json_array()");
+    }
 
     return 0;
 }

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "transform/cypher_transform.h"
 #include "transform/transform_helpers.h"
@@ -1101,13 +1102,23 @@ skip_combined_exists:
                             ctx->error_message = strdup("Failed to get alias for projected variable");
                             return -1;
                         }
-                        /* Extract CTE name from source_expr (e.g., "_with_0.p" -> "_with_0") */
+                        /* Extract CTE name from source_expr (e.g., "_with_0.p" -> "_with_0").
+                         * The alias may be a function-wrapped id reference
+                         * (e.g. "json_extract(_unwind_0.value, '$.id')" for a
+                         * node unwound from collect()); in that case the CTE
+                         * token is the identifier ending at the first '.', so
+                         * scan back from the dot to the start of that token. */
                         char cte_name[64];
                         const char *dot = strchr(alias, '.');
                         if (dot) {
-                            size_t len = dot - alias;
+                            const char *start = dot;
+                            while (start > alias &&
+                                   (isalnum((unsigned char)start[-1]) || start[-1] == '_')) {
+                                start--;
+                            }
+                            size_t len = dot - start;
                             if (len >= sizeof(cte_name)) len = sizeof(cte_name) - 1;
-                            strncpy(cte_name, alias, len);
+                            strncpy(cte_name, start, len);
                             cte_name[len] = '\0';
                         } else {
                             strncpy(cte_name, alias, sizeof(cte_name) - 1);

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -698,8 +698,32 @@ static int transform_match_pattern(cypher_transform_context *ctx, ast_node *patt
     ctx->anon_node_base = ctx->anon_node_counter;
     ctx->anon_node_counter += path->elements->count;
     
-    /* If path has a variable name, register it as a path variable */
+    /* If path has a variable name, register it as a path variable.
+     * T-0333 (Match6 [5]/[7]/[9]): if the path has a name (e.g.
+     * `MATCH p = (a:L)<--(:M)`), the path projection needs to reference
+     * every element by alias to build the hydrated path. Anonymous
+     * nodes/rels would emit `null` and produce broken `[id,null,null]`
+     * strings. Synthesize names here so the subsequent MATCH-emission
+     * pass registers each one and the path projection can resolve them. */
     if (path->var_name) {
+        for (int j = 0; j < path->elements->count; j++) {
+            ast_node *el = path->elements->items[j];
+            if (el->type == AST_NODE_NODE_PATTERN) {
+                cypher_node_pattern *np = (cypher_node_pattern*)el;
+                if (!np->variable || !np->variable[0]) {
+                    char gen[48];
+                    snprintf(gen, sizeof(gen), "_pv_n%d_%d", ctx->anon_node_base, j);
+                    np->variable = strdup(gen);
+                }
+            } else if (el->type == AST_NODE_REL_PATTERN) {
+                cypher_rel_pattern *rp = (cypher_rel_pattern*)el;
+                if (!rp->variable || !rp->variable[0]) {
+                    char gen[48];
+                    snprintf(gen, sizeof(gen), "_pv_e%d_%d", ctx->anon_node_base, j);
+                    rp->variable = strdup(gen);
+                }
+            }
+        }
         CYPHER_DEBUG("Registering path variable: %s with %d elements", path->var_name, path->elements->count);
         if (register_path_variable(ctx, path->var_name, path) < 0) {
             /* register_path_variable already set a specific message if it

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -1070,11 +1070,10 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                         "EXISTS (SELECT 1 FROM edge_props_bool WHERE edge_id = e.id AND key_id = pk.id) OR "
                                         "EXISTS (SELECT 1 FROM edge_props_json WHERE edge_id = e.id AND key_id = pk.id)"
                                       "), json('{}'))"
-                                  ")) "
-                                  "FROM edges e WHERE e.id IN ("
-                                    "SELECT CAST(value AS INTEGER) FROM json_each('[' || %s.path_ids || ']')"
-                                  ") ORDER BY instr(',' || %s.path_ids || ',', ',' || e.id || ','))",
-                                  alias, alias);
+                                  ") ORDER BY je.key) "
+                                  "FROM json_each('[' || %s.elem_ids || ']') je "
+                                  "JOIN edges e ON e.id = je.value WHERE (je.key %% 2) = 1)",
+                                  alias);
                                 goto edge_alias_projection_done;
                             }
                             /* Edge variable - return full relationship object,

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -1265,6 +1265,27 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                     }
                 }
 
+                /* Dynamic (non-literal) key on a node/edge variable:
+                 * `n['na'+'me']` / `n[$key]`. Resolve via a runtime EAV
+                 * lookup by key (Graph7 [1]-[3]). The base node/edge isn't a
+                 * JSON object in scope, so _gql_subscript on the hydrated
+                 * object can't find the property. */
+                if (subscript->expr->type == AST_NODE_IDENTIFIER) {
+                    cypher_identifier *bid = (cypher_identifier*)subscript->expr;
+                    transform_var *bv = transform_var_lookup(ctx->var_ctx, bid->name);
+                    if (bv && (bv->kind == VAR_KIND_NODE || bv->kind == VAR_KIND_EDGE)) {
+                        const char *balias = transform_var_get_alias(ctx->var_ctx, bid->name);
+                        bool alias_is_id = transform_var_alias_is_id(ctx->var_ctx, bid->name);
+                        append_sql(ctx, "%s(%s%s, ",
+                                   bv->kind == VAR_KIND_EDGE ? "_gql_edge_prop" : "_gql_node_prop",
+                                   balias ? balias : bid->name,
+                                   alias_is_id ? "" : ".id");
+                        if (transform_expression(ctx, subscript->index) < 0) return -1;
+                        append_sql(ctx, ")");
+                        break;
+                    }
+                }
+
                 /* Route through _gql_subscript() which performs runtime
                  * type checking (TypeError for non-list/map values or
                  * mismatched index types) and handles negative indices.

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -849,7 +849,76 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                 }
                             }
 
-                            if (has_varlen && varlen_alias) {
+                            if (path_var->path_type == VAR_PATH_COMPREHENSION) {
+                                /* T-0332: pattern comprehension path — emit fully hydrated
+                                 * path JSON ({nodes:[...], rels:[...]}) so it survives nested
+                                 * inside a json_group_array aggregate without needing executor
+                                 * post-processing of list elements. Build using json_object so
+                                 * SQLite quotes/escapes correctly. */
+                                append_sql(ctx, "json_object('nodes', json_array(");
+                                bool first_n = true;
+                                for (int i = 0; i < path_var->path_elements->count; i++) {
+                                    ast_node *element = path_var->path_elements->items[i];
+                                    if (element->type != AST_NODE_NODE_PATTERN) continue;
+                                    cypher_node_pattern *np = (cypher_node_pattern*)element;
+                                    const char *a = np->variable ? transform_var_get_alias(ctx->var_ctx, np->variable) : NULL;
+                                    if (!first_n) append_sql(ctx, ", ");
+                                    first_n = false;
+                                    if (!a) { append_sql(ctx, "null"); continue; }
+                                    append_sql(ctx,
+                                        "json_object("
+                                        "'id', %s.id, "
+                                        "'labels', COALESCE((SELECT json_group_array(label) FROM node_labels WHERE node_id = %s.id), json('[]')), "
+                                        "'properties', COALESCE((SELECT json_group_object(pk.key, COALESCE("
+                                            "(SELECT npt.value FROM node_props_text npt WHERE npt.node_id = %s.id AND npt.key_id = pk.id), "
+                                            "(SELECT npi.value FROM node_props_int npi WHERE npi.node_id = %s.id AND npi.key_id = pk.id), "
+                                            "(SELECT npr.value FROM node_props_real npr WHERE npr.node_id = %s.id AND npr.key_id = pk.id), "
+                                            "(SELECT json(CASE WHEN npb.value THEN 'true' ELSE 'false' END) FROM node_props_bool npb WHERE npb.node_id = %s.id AND npb.key_id = pk.id), "
+                                            "(SELECT json(npj.value) FROM node_props_json npj WHERE npj.node_id = %s.id AND npj.key_id = pk.id))) "
+                                        "FROM property_keys pk WHERE "
+                                            "EXISTS (SELECT 1 FROM node_props_text WHERE node_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM node_props_int  WHERE node_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM node_props_real WHERE node_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM node_props_bool WHERE node_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM node_props_json WHERE node_id = %s.id AND key_id = pk.id)"
+                                        "), json('{}'))"
+                                        ")",
+                                        a, a, a, a, a, a, a, a, a, a, a, a);
+                                }
+                                append_sql(ctx, "), 'rels', json_array(");
+                                bool first_r = true;
+                                for (int i = 0; i < path_var->path_elements->count; i++) {
+                                    ast_node *element = path_var->path_elements->items[i];
+                                    if (element->type != AST_NODE_REL_PATTERN) continue;
+                                    cypher_rel_pattern *rp = (cypher_rel_pattern*)element;
+                                    const char *a = rp->variable ? transform_var_get_alias(ctx->var_ctx, rp->variable) : NULL;
+                                    if (!first_r) append_sql(ctx, ", ");
+                                    first_r = false;
+                                    if (!a) { append_sql(ctx, "null"); continue; }
+                                    append_sql(ctx,
+                                        "json_object("
+                                        "'id', %s.id, "
+                                        "'type', %s.type, "
+                                        "'startNode', %s.source_id, "
+                                        "'endNode', %s.target_id, "
+                                        "'properties', COALESCE((SELECT json_group_object(pk.key, COALESCE("
+                                            "(SELECT ept.value FROM edge_props_text ept WHERE ept.edge_id = %s.id AND ept.key_id = pk.id), "
+                                            "(SELECT epi.value FROM edge_props_int  epi WHERE epi.edge_id = %s.id AND epi.key_id = pk.id), "
+                                            "(SELECT epr.value FROM edge_props_real epr WHERE epr.edge_id = %s.id AND epr.key_id = pk.id), "
+                                            "(SELECT json(CASE WHEN epb.value THEN 'true' ELSE 'false' END) FROM edge_props_bool epb WHERE epb.edge_id = %s.id AND epb.key_id = pk.id), "
+                                            "(SELECT json(epj.value) FROM edge_props_json epj WHERE epj.edge_id = %s.id AND epj.key_id = pk.id))) "
+                                        "FROM property_keys pk WHERE "
+                                            "EXISTS (SELECT 1 FROM edge_props_text WHERE edge_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM edge_props_int  WHERE edge_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM edge_props_real WHERE edge_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM edge_props_bool WHERE edge_id = %s.id AND key_id = pk.id) OR "
+                                            "EXISTS (SELECT 1 FROM edge_props_json WHERE edge_id = %s.id AND key_id = pk.id)"
+                                        "), json('{}'))"
+                                        ")",
+                                        a, a, a, a, a, a, a, a, a, a, a, a, a, a);
+                                }
+                                append_sql(ctx, "))");
+                            } else if (has_varlen && varlen_alias) {
                                 /* For variable-length paths, use the CTE's path_ids column */
                                 append_sql(ctx, "'[' || %s.path_ids || ']'", varlen_alias);
                             } else {
@@ -1675,7 +1744,7 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                         }
                     }
                     transform_var_register_path(ctx->var_ctx, comp->path_var, NULL,
-                                                path->elements, VAR_PATH_NORMAL);
+                                                path->elements, VAR_PATH_COMPREHENSION);
                 }
 
                 /* Add WHERE clause for joins and constraints */

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -337,8 +337,11 @@ int transform_return_clause(cypher_transform_context *ctx, cypher_return *ret)
                     snprintf(expr_buf, sizeof(expr_buf), "%s.type", var->table_alias);
                     sql_select(ctx->unified_builder, expr_buf, var->name);
                 } else if (var->kind == VAR_KIND_PROJECTED) {
-                    /* Projected variable - alias IS the value */
-                    sql_select(ctx->unified_builder, var->table_alias, var->name);
+                    /* Projected variable — the source expression (e.g. CTE
+                     * column ref) lives on source_expr; table_alias is NULL.
+                     * T-0333: use get_alias to pick the right one. */
+                    const char *src = transform_var_get_alias(ctx->var_ctx, var->name);
+                    if (src) sql_select(ctx->unified_builder, src, var->name);
                 }
                 added++;
             }

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -1627,6 +1627,25 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                     }
                 }
 
+                /* T-0332: register relationship variables so r.prop / r.type
+                 * resolve inside the projection. The rel's alias is
+                 * `_pc_e<rel_index>` matching the FROM-clause emission above. */
+                {
+                    int rel_i = 0;
+                    for (int i = 0; i < path->elements->count; i++) {
+                        ast_node *element = path->elements->items[i];
+                        if (element->type == AST_NODE_REL_PATTERN && i > 0 && i < path->elements->count - 1) {
+                            cypher_rel_pattern *rel = (cypher_rel_pattern*)element;
+                            if (rel->variable && rel->variable[0]) {
+                                char alias[32];
+                                snprintf(alias, sizeof(alias), "_pc_e%d", rel_i);
+                                transform_var_register_edge(ctx->var_ctx, rel->variable, alias, NULL);
+                            }
+                            rel_i++;
+                        }
+                    }
+                }
+
                 /* Add WHERE clause for joins and constraints */
                 append_sql(ctx, " WHERE ");
 

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -293,6 +293,10 @@ int transform_return_clause(cypher_transform_context *ctx, cypher_return *ret)
             for (int vi = 0; vi < var_count; vi++) {
                 transform_var *var = transform_var_at(ctx->var_ctx, vi);
                 if (!var || !var->is_visible || !var->name) continue;
+                /* RETURN * exposes only user-named variables, not the synthetic
+                 * aliases generated for anonymous nodes/rels (With1 [1]/[2]). */
+                if (strncmp(var->name, "_gql_default_alias_", 19) == 0 ||
+                    strncmp(var->name, "__unnamed_rel_", 14) == 0) continue;
 
                 /* Build expression for this variable based on its kind */
                 if (var->kind == VAR_KIND_NODE) {

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -1629,13 +1629,23 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
 
                 /* T-0332: register relationship variables so r.prop / r.type
                  * resolve inside the projection. The rel's alias is
-                 * `_pc_e<rel_index>` matching the FROM-clause emission above. */
+                 * `_pc_e<rel_index>` matching the FROM-clause emission above.
+                 * Also synthesize a variable on anonymous rels when there is
+                 * a path-assignment so the path projection can reference the
+                 * rel's id (otherwise it emits `null` for the rel slot). */
                 {
                     int rel_i = 0;
                     for (int i = 0; i < path->elements->count; i++) {
                         ast_node *element = path->elements->items[i];
                         if (element->type == AST_NODE_REL_PATTERN && i > 0 && i < path->elements->count - 1) {
                             cypher_rel_pattern *rel = (cypher_rel_pattern*)element;
+                            if (!rel->variable || !rel->variable[0]) {
+                                if (comp->path_var) {
+                                    char gen[32];
+                                    snprintf(gen, sizeof(gen), "_pc_relv%d", rel_i);
+                                    rel->variable = strdup(gen);
+                                }
+                            }
                             if (rel->variable && rel->variable[0]) {
                                 char alias[32];
                                 snprintf(alias, sizeof(alias), "_pc_e%d", rel_i);
@@ -1644,6 +1654,28 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                             rel_i++;
                         }
                     }
+                }
+
+                /* T-0332: also synthesize variable names on anonymous nodes
+                 * when there is a path-assignment, and register the path. */
+                if (comp->path_var) {
+                    for (int i = 0; i < path->elements->count; i++) {
+                        ast_node *element = path->elements->items[i];
+                        if (element->type == AST_NODE_NODE_PATTERN) {
+                            cypher_node_pattern *np = (cypher_node_pattern*)element;
+                            if (!np->variable || !np->variable[0]) {
+                                int slot = i / 2;
+                                char gen[32];
+                                snprintf(gen, sizeof(gen), "_pc_nv%d", slot);
+                                np->variable = strdup(gen);
+                                char alias[32];
+                                snprintf(alias, sizeof(alias), "_pc_n%d", slot);
+                                transform_var_register_node(ctx->var_ctx, np->variable, alias, NULL);
+                            }
+                        }
+                    }
+                    transform_var_register_path(ctx->var_ctx, comp->path_var, NULL,
+                                                path->elements, VAR_PATH_NORMAL);
                 }
 
                 /* Add WHERE clause for joins and constraints */

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -57,6 +57,7 @@ bool ast_yields_boolean(ast_node *expr)
     if (expr->type == AST_NODE_NOT_EXPR ||
         expr->type == AST_NODE_NULL_CHECK ||
         expr->type == AST_NODE_LIST_PREDICATE ||
+        expr->type == AST_NODE_LABEL_EXPR ||
         expr->type == AST_NODE_EXISTS_EXPR) return true;
     if (expr->type == AST_NODE_LITERAL &&
         ((cypher_literal*)expr)->literal_type == LITERAL_BOOLEAN) return true;

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -51,7 +51,7 @@ const char* get_pending_prop_joins(cypher_transform_context *ctx)
  * predicate at the top-of-RETURN-item wrap site below. Used when
  * emitting list/map values so booleans inside literals get tagged
  * with GQL_SUBTYPE_BOOLEAN (T-0304). */
-static bool ast_yields_boolean(ast_node *expr)
+bool ast_yields_boolean(ast_node *expr)
 {
     if (!expr) return false;
     if (expr->type == AST_NODE_NOT_EXPR ||

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -835,9 +835,18 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                         if (path_var && path_var->path_elements) {
                             CYPHER_DEBUG("Found path variable metadata for '%s' with %d elements", id->name, path_var->path_elements->count);
 
-                            /* Check if this is a variable-length path (shortestPath, etc.) */
+                            /* Check if this is a variable-length path (shortestPath, etc.).
+                             * The interleaved elem_ids path projection only applies
+                             * when the WHOLE path is a single varlen segment; a path
+                             * mixing fixed and varlen rels (Match7 [19]) has parts
+                             * outside this CTE and must keep the legacy behavior. */
                             bool has_varlen = false;
                             const char *varlen_alias = NULL;
+                            int rel_count = 0;
+                            for (int i = 0; i < path_var->path_elements->count; i++) {
+                                if (path_var->path_elements->items[i]->type == AST_NODE_REL_PATTERN)
+                                    rel_count++;
+                            }
                             for (int i = 0; i < path_var->path_elements->count; i++) {
                                 ast_node *element = path_var->path_elements->items[i];
                                 if (element->type == AST_NODE_REL_PATTERN) {
@@ -851,6 +860,10 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                     }
                                 }
                             }
+                            /* Only a single-varlen-segment path uses the interleaved
+                             * elem_ids array; mixed fixed+varlen paths keep the legacy
+                             * path_ids projection (Match7 [19]). */
+                            bool single_varlen = has_varlen && rel_count == 1;
 
                             if (path_var->path_type == VAR_PATH_COMPREHENSION) {
                                 /* T-0332: pattern comprehension path — emit fully hydrated
@@ -922,8 +935,15 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                 }
                                 append_sql(ctx, "))");
                             } else if (has_varlen && varlen_alias) {
-                                /* For variable-length paths, use the CTE's path_ids column */
-                                append_sql(ctx, "'[' || %s.path_ids || ']'", varlen_alias);
+                                /* Single-varlen path: use the CTE's interleaved
+                                 * elem_ids (node,edge,node,...) so the executor
+                                 * hydrates the full path, not just endpoints
+                                 * (Match6 [15]/[16]/[19]/[20]). Mixed fixed+varlen
+                                 * paths keep the legacy node-only path_ids. */
+                                if (single_varlen)
+                                    append_sql(ctx, "'[' || %s.elem_ids || ']'", varlen_alias);
+                                else
+                                    append_sql(ctx, "'[' || %s.path_ids || ']'", varlen_alias);
                             } else {
                                 /* Regular path - build from individual element IDs */
                                 append_sql(ctx, "'[");

--- a/src/backend/transform/transform_unwind.c
+++ b/src/backend/transform/transform_unwind.c
@@ -43,8 +43,23 @@ int transform_unwind_clause(cypher_transform_context *ctx, cypher_unwind *unwind
      * in scope so we can carry them through the UNWIND CTE. Without this,
      * `WITH 1 AS a UNWIND [1,2] AS x RETURN a, x` errors out because the
      * UNWIND drops `a` from the var context. */
+    /* T-0333 (Unwind1 [12]): if UNWIND source is an identifier referencing
+     * a list-of-nodes/edges (e.g. `collect(n)`), capture the inner kind
+     * before the var-ctx reset so we can rebind the unwound alias with the
+     * proper kind. */
+    var_kind unwind_inner_kind = VAR_KIND_PROJECTED;
+    if (unwind->expr && unwind->expr->type == AST_NODE_IDENTIFIER) {
+        cypher_identifier *id = (cypher_identifier*)unwind->expr;
+        transform_var *src = transform_var_lookup(ctx->var_ctx, id->name);
+        if (src && (src->list_inner_kind == VAR_KIND_NODE ||
+                    src->list_inner_kind == VAR_KIND_EDGE)) {
+            unwind_inner_kind = src->list_inner_kind;
+        }
+    }
+
     char *carry_names[64];
     char *carry_aliases[64];
+    var_kind carry_kinds[64];
     int carry_count = 0;
     {
         int n = transform_var_count(ctx->var_ctx);
@@ -52,13 +67,24 @@ int transform_unwind_clause(cypher_transform_context *ctx, cypher_unwind *unwind
             transform_var *v = transform_var_at(ctx->var_ctx, i);
             if (!v || !v->name) continue;
             if (!v->is_visible) continue;
-            if (v->kind != VAR_KIND_PROJECTED) continue;
-            /* Projected vars store the source expression here (e.g.
-             * "_with_0.msg"); table_alias may be NULL for them. */
+            /* T-0333 (Unwind1 [12]): carry projected vars and post-WITH
+             * node/edge vars. Post-WITH node/edge variables hold an
+             * `<cte>.<col>` reference (alias IS the id), so they thread
+             * through identically to a projected scalar. */
+            if (v->kind != VAR_KIND_PROJECTED &&
+                v->kind != VAR_KIND_NODE &&
+                v->kind != VAR_KIND_EDGE) continue;
             const char *alias = v->source_expr ? v->source_expr : v->table_alias;
             if (!alias) continue;
+            /* For post-WITH node/edge vars, table_alias is the id column
+             * reference (alias_is_id is true). For pre-WITH node/edge
+             * vars (just-emitted MATCH), table_alias is the SQL table
+             * alias and we can't carry those through an UNWIND CTE —
+             * skip them. */
+            if ((v->kind == VAR_KIND_NODE || v->kind == VAR_KIND_EDGE) && !v->alias_is_id) continue;
             carry_names[carry_count]   = strdup(v->name);
             carry_aliases[carry_count] = strdup(alias);
+            carry_kinds[carry_count]   = v->kind;
             carry_count++;
         }
     }
@@ -440,14 +466,24 @@ int transform_unwind_clause(cypher_transform_context *ctx, cypher_unwind *unwind
     /* Clear old variables - UNWIND creates a new scope */
     transform_var_ctx_reset(ctx->var_ctx);
 
-    /* Restore the projected variables we captured pre-reset, now pointing
-     * at the new UNWIND CTE's columns (which we projected through above). */
+    /* Restore the carried variables we captured pre-reset, now pointing
+     * at the new UNWIND CTE's columns. Preserve original kind so post-UNWIND
+     * code paths see nodes/edges as nodes/edges (json-object projection,
+     * property access via id) rather than scalars. */
     for (int i = 0; i < carry_count; i++) {
         if (has_carry) {
             char src[256], _ib[128];
             snprintf(src, sizeof(src), "%s.%s", cte_name,
                      sql_ident(_ib, sizeof(_ib), carry_names[i]));
-            transform_var_register_projected(ctx->var_ctx, carry_names[i], src);
+            if (carry_kinds[i] == VAR_KIND_NODE) {
+                transform_var_register_node(ctx->var_ctx, carry_names[i], src, NULL);
+                transform_var_set_alias_is_id(ctx->var_ctx, carry_names[i], true);
+            } else if (carry_kinds[i] == VAR_KIND_EDGE) {
+                transform_var_register_edge(ctx->var_ctx, carry_names[i], src, NULL);
+                transform_var_set_alias_is_id(ctx->var_ctx, carry_names[i], true);
+            } else {
+                transform_var_register_projected(ctx->var_ctx, carry_names[i], src);
+            }
         }
         free(carry_names[i]);
         free(carry_aliases[i]);
@@ -455,10 +491,30 @@ int transform_unwind_clause(cypher_transform_context *ctx, cypher_unwind *unwind
     dbuf_free(&carry_cols);
     dbuf_free(&carry_cols_orig);
 
-    /* Register the unwound variable in unified system */
+    /* Register the unwound variable. When the source was a tagged
+     * list-of-nodes/edges, rebind as that kind with alias_is_id so
+     * post-UNWIND MATCH/RETURN treat it as a bound entity (T-0333). */
     char unwind_source[256];
     snprintf(unwind_source, sizeof(unwind_source), "%s.value", cte_name);
-    transform_var_register_projected(ctx->var_ctx, unwind->alias, unwind_source);
+    if (unwind_inner_kind == VAR_KIND_NODE || unwind_inner_kind == VAR_KIND_EDGE) {
+        /* collect() hydrates each element to a full JSON object
+         * ({id,labels,properties}), so the unwound value is an object, not a
+         * raw id. Bind the entity's alias to json_extract(value,'$.id') so it
+         * behaves like any other post-WITH alias_is_id entity: edge joins
+         * constrain on the id, RETURN re-hydrates from the DB by id, and
+         * property access resolves through the id. */
+        char id_source[300];
+        snprintf(id_source, sizeof(id_source),
+                 "json_extract(%s.value, '$.id')", cte_name);
+        if (unwind_inner_kind == VAR_KIND_NODE) {
+            transform_var_register_node(ctx->var_ctx, unwind->alias, id_source, NULL);
+        } else {
+            transform_var_register_edge(ctx->var_ctx, unwind->alias, id_source, NULL);
+        }
+        transform_var_set_alias_is_id(ctx->var_ctx, unwind->alias, true);
+    } else {
+        transform_var_register_projected(ctx->var_ctx, unwind->alias, unwind_source);
+    }
 
     /* Set up FROM for the outer query — SELECT columns are added by RETURN clause */
     sql_from(ctx->unified_builder, cte_name, NULL);

--- a/src/backend/transform/transform_variables.c
+++ b/src/backend/transform/transform_variables.c
@@ -147,6 +147,10 @@ int transform_var_register(transform_var_context *ctx,
     var->declared_in_clause = ctx->current_clause;
     var->is_visible = true;
     var->is_bound = false;
+    /* VAR_KIND_NODE == 0, so the memset above would otherwise tag every list
+     * as a list-of-nodes. Default to PROJECTED ("unknown / scalar"); only an
+     * explicit collect(node|edge) sets this to NODE/EDGE. */
+    var->list_inner_kind = VAR_KIND_PROJECTED;
 
     ctx->count++;
     return 0;

--- a/src/backend/transform/transform_with.c
+++ b/src/backend/transform/transform_with.c
@@ -170,6 +170,60 @@ static int validate_identifiers_in_scope(cypher_transform_context *ctx, ast_node
     return validate_identifiers_in_scope_ex(ctx, expr, NULL, 0);
 }
 
+/* True if `expr` references a variable that is live in the CURRENT (input)
+ * scope but is NOT among `proj` (the WITH's projected output names) — i.e. a
+ * variable the WITH discards. Such an ORDER BY can only be evaluated inside
+ * the WITH CTE (where the input tables are still in FROM), not on the outer
+ * SELECT over the CTE. (WithOrderBy2 [21]-[24].) Mirrors the walk of
+ * validate_identifiers_in_scope_ex. */
+static bool expr_refs_dropped_input_var(cypher_transform_context *ctx, ast_node *expr,
+                                        char **proj, int proj_count)
+{
+    if (!expr) return false;
+    switch (expr->type) {
+        case AST_NODE_IDENTIFIER: {
+            cypher_identifier *id = (cypher_identifier*)expr;
+            if (!id->name) return false;
+            if (!transform_var_lookup(ctx->var_ctx, id->name)) return false; /* not input-scope */
+            for (int i = 0; i < proj_count; i++)
+                if (proj[i] && strcmp(proj[i], id->name) == 0) return false;  /* survives WITH */
+            return true;
+        }
+        case AST_NODE_PROPERTY:
+            return expr_refs_dropped_input_var(ctx, ((cypher_property*)expr)->expr, proj, proj_count);
+        case AST_NODE_BINARY_OP: {
+            cypher_binary_op *b = (cypher_binary_op*)expr;
+            return expr_refs_dropped_input_var(ctx, b->left, proj, proj_count) ||
+                   expr_refs_dropped_input_var(ctx, b->right, proj, proj_count);
+        }
+        case AST_NODE_NOT_EXPR:
+            return expr_refs_dropped_input_var(ctx, ((cypher_not_expr*)expr)->expr, proj, proj_count);
+        case AST_NODE_NULL_CHECK:
+            return expr_refs_dropped_input_var(ctx, ((cypher_null_check*)expr)->expr, proj, proj_count);
+        case AST_NODE_FUNCTION_CALL: {
+            cypher_function_call *fc = (cypher_function_call*)expr;
+            if (fc->args)
+                for (int i = 0; i < fc->args->count; i++)
+                    if (expr_refs_dropped_input_var(ctx, fc->args->items[i], proj, proj_count)) return true;
+            return false;
+        }
+        case AST_NODE_LIST: {
+            cypher_list *l = (cypher_list*)expr;
+            if (l->items)
+                for (int i = 0; i < l->items->count; i++)
+                    if (expr_refs_dropped_input_var(ctx, l->items->items[i], proj, proj_count)) return true;
+            return false;
+        }
+        case AST_NODE_SUBSCRIPT: {
+            cypher_subscript *s = (cypher_subscript*)expr;
+            return expr_refs_dropped_input_var(ctx, s->expr, proj, proj_count) ||
+                   expr_refs_dropped_input_var(ctx, s->index, proj, proj_count);
+        }
+        default:
+            return false;
+    }
+}
+
 /*
  * Transform an expression to a dynamically allocated string.
  * Uses a temporary buffer to capture output, then returns the result.
@@ -574,21 +628,60 @@ with_star_columns_done:
         dbuf_append(&cte_body, group_by_clause);
     }
 
+    /* WithOrderBy2 [21]-[24]: when the WITH's ORDER BY references an input
+     * variable that the WITH drops (e.g. `WITH a.name AS name ORDER BY
+     * a.name + 'C' DESC`), the outer SELECT over the CTE cannot resolve it,
+     * so the ORDER BY was silently dropped. Emit it INSIDE the CTE body —
+     * transformed in the still-live input scope, where the input tables are
+     * in FROM (projected aliases also resolve there). Only triggers for that
+     * specific case; ORDER BY over projected columns keeps the outer path. */
+    bool order_pushed_to_cte = false;
+    if (with->order_by && with->order_by->count > 0 && !with->pass_all && with->items) {
+        char *proj_names[128]; int proj_n = 0;
+        for (int i = 0; i < with->items->count && proj_n < 128; i++) {
+            cypher_return_item *it = (cypher_return_item*)with->items->items[i];
+            const char *nm = it->alias;
+            if (!nm && it->expr && it->expr->type == AST_NODE_IDENTIFIER)
+                nm = ((cypher_identifier*)it->expr)->name;
+            else if (!nm && it->expr && it->expr->type == AST_NODE_PROPERTY)
+                nm = ((cypher_property*)it->expr)->property_name;
+            if (nm) proj_names[proj_n++] = (char*)nm;
+        }
+        bool needs = false, has_agg_order = false;
+        for (int i = 0; i < with->order_by->count; i++) {
+            cypher_order_by_item *oi = (cypher_order_by_item*)with->order_by->items[i];
+            if (find_aggregating_call(oi->expr)) has_agg_order = true;
+            if (expr_refs_dropped_input_var(ctx, oi->expr, proj_names, proj_n)) needs = true;
+        }
+        /* Aggregating ORDER BY exprs (e.g. ORDER BY count(x) + 1) interact with
+         * the WITH's GROUP BY and must stay on the outer path. (WithOrderBy4 [16].) */
+        if (has_agg_order) needs = false;
+        if (needs) {
+            dbuf_append(&cte_body, " ORDER BY ");
+            for (int i = 0; i < with->order_by->count; i++) {
+                cypher_order_by_item *oi = (cypher_order_by_item*)with->order_by->items[i];
+                if (i > 0) dbuf_append(&cte_body, ", ");
+                char *oe = transform_expression_to_string(ctx, oi->expr);
+                dbuf_appendf(&cte_body, "_gql_order_key(%s)%s", oe ? oe : "NULL",
+                             oi->descending ? " DESC" : "");
+                free(oe);
+            }
+            order_pushed_to_cte = true;
+        }
+    }
+
     /* T-0323: emit LIMIT / OFFSET inside the CTE body when WITH
-     * has them AND no ORDER BY is present. The outer-LIMIT
-     * positioning previously applied the limit to the final
-     * projection instead of the WITH's row set.
+     * has them AND no ORDER BY is present (or the ORDER BY was just pushed
+     * into the CTE above). The outer-LIMIT positioning previously applied
+     * the limit to the final projection instead of the WITH's row set.
      * `MATCH (n) WITH n LIMIT 2 RETURN count(*)` should limit
      * WITH's rows to 2 then count → 2.
      *
-     * When ORDER BY is ALSO present, pushing LIMIT into CTE
-     * without ORDER BY would yield wrong rows. The full ORDER BY
-     * push into CTE is more invasive (alias resolution / aggregate
-     * handling) — leave that combined case on the outer-builder
-     * path for now (it's at least order-correct, even if the
-     * count semantics aren't). Tracked for follow-up. */
+     * When ORDER BY is present on the OUTER path (not pushed into the CTE),
+     * pushing LIMIT into the CTE without ORDER BY would yield wrong rows —
+     * leave that combined case on the outer-builder path. */
     if ((with->limit || with->skip) &&
-        (!with->order_by || with->order_by->count == 0)) {
+        ((!with->order_by || with->order_by->count == 0) || order_pushed_to_cte)) {
         char *cte_limit_str = with->limit ? transform_expression_to_string(ctx, with->limit) : NULL;
         char *cte_skip_str = with->skip ? transform_expression_to_string(ctx, with->skip) : NULL;
         if (cte_limit_str) {
@@ -882,15 +975,17 @@ with_star_columns_done:
                 return -1;
             }
         }
-        /* ORDER BY stays on the outer builder for now — pushing it
-         * into the CTE body has alias-resolution issues that need
-         * more careful handling (T-0323 follow-up). */
-        for (int i = 0; i < with->order_by->count; i++) {
-            cypher_order_by_item *order_item = (cypher_order_by_item*)with->order_by->items[i];
-            char *order_expr = transform_expression_to_string(ctx, order_item->expr);
-            if (order_expr) {
-                sql_order_by(ctx->unified_builder, order_expr, order_item->descending);
-                free(order_expr);
+        /* ORDER BY normally stays on the outer builder (over the CTE).
+         * If it referenced a dropped input variable it was already emitted
+         * inside the CTE body above (order_pushed_to_cte) — skip here. */
+        if (!order_pushed_to_cte) {
+            for (int i = 0; i < with->order_by->count; i++) {
+                cypher_order_by_item *order_item = (cypher_order_by_item*)with->order_by->items[i];
+                char *order_expr = transform_expression_to_string(ctx, order_item->expr);
+                if (order_expr) {
+                    sql_order_by(ctx->unified_builder, order_expr, order_item->descending);
+                    free(order_expr);
+                }
             }
         }
     }
@@ -913,7 +1008,8 @@ with_star_columns_done:
      * Use the outer-builder path for those cases. Otherwise the
      * CTE-inline above already handled it; skip here. */
     bool inline_limit_done = (with->limit || with->skip) &&
-                             (!with->order_by || with->order_by->count == 0);
+                             ((!with->order_by || with->order_by->count == 0) ||
+                              order_pushed_to_cte);
     if (!inline_limit_done && with->limit) {
         limit_str = transform_expression_to_string(ctx, with->limit);
         if (limit_str) {

--- a/src/backend/transform/transform_with.c
+++ b/src/backend/transform/transform_with.c
@@ -386,18 +386,21 @@ int transform_with_clause(cypher_transform_context *ctx, cypher_with *with)
                     const char *p_real = is_edge_var ? "edge_props_real" : "node_props_real";
                     const char *p_text = is_edge_var ? "edge_props_text" : "node_props_text";
                     const char *p_bool = is_edge_var ? "edge_props_bool" : "node_props_bool";
+                    const char *p_json = is_edge_var ? "edge_props_json" : "node_props_json";
                     const char *entity_col = is_edge_var ? "edge_id" : "node_id";
                     dbuf_appendf(&col_buf,
                         "(SELECT COALESCE("
                         "(SELECT npi.value FROM %s npi JOIN property_keys pk ON npi.key_id = pk.id WHERE npi.%s = %s%s AND pk.key = '%s'), "
                         "(SELECT npr.value FROM %s npr JOIN property_keys pk ON npr.key_id = pk.id WHERE npr.%s = %s%s AND pk.key = '%s'), "
                         "(SELECT npt.value FROM %s npt JOIN property_keys pk ON npt.key_id = pk.id WHERE npt.%s = %s%s AND pk.key = '%s'), "
-                        "(SELECT CASE WHEN npb.value THEN 'true' ELSE 'false' END FROM %s npb JOIN property_keys pk ON npb.key_id = pk.id WHERE npb.%s = %s%s AND pk.key = '%s')"
+                        "(SELECT CASE WHEN npb.value THEN 'true' ELSE 'false' END FROM %s npb JOIN property_keys pk ON npb.key_id = pk.id WHERE npb.%s = %s%s AND pk.key = '%s'), "
+                        "(SELECT npj.value FROM %s npj JOIN property_keys pk ON npj.key_id = pk.id WHERE npj.%s = %s%s AND pk.key = '%s')"
                         ")) AS %s",
                         p_int, entity_col, alias, id_suffix, prop->property_name,
                         p_real, entity_col, alias, id_suffix, prop->property_name,
                         p_text, entity_col, alias, id_suffix, prop->property_name,
                         p_bool, entity_col, alias, id_suffix, prop->property_name,
+                        p_json, entity_col, alias, id_suffix, prop->property_name,
                         ({ static char _idbuf[128]; sql_ident(_idbuf, sizeof(_idbuf), col_name); }));
                     /* Add the projected column name to GROUP BY (not node id) */
                     if (group_count > 0) {

--- a/src/backend/transform/transform_with.c
+++ b/src/backend/transform/transform_with.c
@@ -610,6 +610,11 @@ with_star_columns_done:
     /* Before reset - save source variable kinds for simple identifiers
      * This preserves node/edge status so property lookups work after WITH */
     var_kind *source_kinds = NULL;
+    /* T-0333 (Unwind1 [12]): for `collect(<node|edge var>) AS x` items, capture
+     * the collected element's kind BEFORE the var-ctx reset (the source var is
+     * wiped by the reset below), so the projection loop can tag list_inner_kind
+     * on x for a downstream UNWIND to rebind elements as nodes/edges. */
+    var_kind *inner_kinds = NULL;
     int saved_var_count = 0;
     char **saved_var_names = NULL;
     var_kind *saved_var_kinds = NULL;
@@ -631,9 +636,11 @@ with_star_columns_done:
         }
     } else if (with->items && with->items->count > 0) {
         source_kinds = calloc(with->items->count, sizeof(var_kind));
+        inner_kinds = calloc(with->items->count, sizeof(var_kind));
         if (source_kinds) {
             for (int i = 0; i < with->items->count; i++) {
                 cypher_return_item *item = (cypher_return_item*)with->items->items[i];
+                if (inner_kinds) inner_kinds[i] = VAR_KIND_PROJECTED;
                 if (item->expr->type == AST_NODE_IDENTIFIER) {
                     cypher_identifier *id = (cypher_identifier*)item->expr;
                     transform_var *var = transform_var_lookup(ctx->var_ctx, id->name);
@@ -644,6 +651,23 @@ with_star_columns_done:
                     }
                 } else {
                     source_kinds[i] = VAR_KIND_PROJECTED;
+                    /* collect(<identifier>) — record the element's kind now,
+                     * while the source var is still in scope. */
+                    if (inner_kinds && item->expr->type == AST_NODE_FUNCTION_CALL) {
+                        cypher_function_call *fc = (cypher_function_call*)item->expr;
+                        if (fc->function_name &&
+                            strcasecmp(fc->function_name, "collect") == 0 &&
+                            fc->args && fc->args->count == 1 &&
+                            fc->args->items[0] &&
+                            fc->args->items[0]->type == AST_NODE_IDENTIFIER) {
+                            cypher_identifier *aid = (cypher_identifier*)fc->args->items[0];
+                            transform_var *src = transform_var_lookup(ctx->var_ctx, aid->name);
+                            if (src && (src->kind == VAR_KIND_NODE ||
+                                        src->kind == VAR_KIND_EDGE)) {
+                                inner_kinds[i] = src->kind;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -737,6 +761,17 @@ with_star_columns_done:
                     CYPHER_DEBUG("WITH: Registered edge variable '%s' -> %s (alias_is_id)", col_name, select_expr);
                 } else {
                     transform_var_register_projected(ctx->var_ctx, col_name, select_expr);
+                    /* T-0333 (Unwind1 [12]): when this WITH item is
+                     * `collect(<node|edge_var>)`, tag the projected var so a
+                     * downstream UNWIND can rebind elements as nodes/edges.
+                     * inner_kinds[i] was captured pre-reset (the source var is
+                     * no longer in scope here). */
+                    if (inner_kinds &&
+                        (inner_kinds[i] == VAR_KIND_NODE ||
+                         inner_kinds[i] == VAR_KIND_EDGE)) {
+                        transform_var *dst = transform_var_lookup(ctx->var_ctx, col_name);
+                        if (dst) dst->list_inner_kind = inner_kinds[i];
+                    }
                     /* Mark vars whose projection is a scalar literal /
                      * scalar expression so MATCH can later reject
                      * `WITH 123 AS n MATCH (n)`. */
@@ -766,6 +801,7 @@ with_star_columns_done:
 
     /* Free saved kinds array */
     free(source_kinds);
+    free(inner_kinds);
 
     /* Handle WHERE clause (applied after projection) — only if the pre-WITH
      * translation didn't succeed (i.e., the WHERE references projected

--- a/src/backend/transform/transform_with.c
+++ b/src/backend/transform/transform_with.c
@@ -494,10 +494,25 @@ int transform_with_clause(cypher_transform_context *ctx, cypher_with *with)
                 return -1;
             }
 
-            /* Append to column buffer */
+            /* Boolean-valued projections (comparisons, AND/OR/NOT, quantifiers,
+             * IS NULL, ...) must carry the boolean subtype so a downstream
+             * RETURN of this column renders as a JSON boolean, not 1/0. Wrap the
+             * already-transformed SQL in _gql_bool_str(CASE ...), reusing the
+             * captured text (no second transform — that would double its
+             * side effects). Otherwise `WITH (a = b) AS r RETURN r` returned 1
+             * instead of true (Quantifier9/11 [3]/[4]/[5] family). */
             { char _idbuf[128];
-              dbuf_appendf(&col_buf, "(%s) AS %s", ctx->sql_buffer,
-                           sql_ident(_idbuf, sizeof(_idbuf), col_name)); }
+              const char *expr_sql = ctx->sql_buffer;
+              if (ast_yields_boolean(item->expr)) {
+                  dbuf_appendf(&col_buf,
+                      "(_gql_bool_str(CASE WHEN (%s) IS NULL THEN NULL WHEN (%s) THEN 1 ELSE 0 END)) AS %s",
+                      expr_sql, expr_sql,
+                      sql_ident(_idbuf, sizeof(_idbuf), col_name));
+              } else {
+                  dbuf_appendf(&col_buf, "(%s) AS %s", expr_sql,
+                               sql_ident(_idbuf, sizeof(_idbuf), col_name));
+              }
+            }
 
             /* Restore sql_buffer */
             ctx->sql_size = saved_size;

--- a/src/include/executor/executor_internal.h
+++ b/src/include/executor/executor_internal.h
@@ -112,6 +112,12 @@ int executor_eval_predicate(cypher_executor *executor,
                             ast_node *expr,
                             variable_map *var_map);
 
+/* Evaluate an AST expression against a variable_map and return its value.
+ * Returns 0 (value in out params), -1 (error), -2 (NULL). */
+int executor_eval_value(cypher_executor *executor, ast_node *expr,
+                        variable_map *var_map, property_type *out_type,
+                        property_value *out_value);
+
 /* SET operations with variable map */
 int execute_set_operations(cypher_executor *executor, cypher_set *set, variable_map *var_map, cypher_result *result);
 int execute_set_items(cypher_executor *executor, ast_list *items, variable_map *var_map, cypher_result *result);

--- a/src/include/parser/cypher_ast.h
+++ b/src/include/parser/cypher_ast.h
@@ -475,6 +475,7 @@ typedef struct cypher_pattern_comprehension {
     ast_list *pattern;        /* The pattern to match (list of path elements) */
     ast_node *where_expr;     /* Optional filter condition (NULL if not present) */
     ast_node *collect_expr;   /* Expression to collect (NULL returns matched nodes/rels) */
+    char *path_var;           /* T-0332: optional path variable name from `[p = pattern | expr]` (NULL otherwise) */
 } cypher_pattern_comprehension;
 
 /* CASE expression: CASE [operand] WHEN cond THEN val [...] [ELSE val] END

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -56,6 +56,7 @@ void gql_time_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 void gql_duration_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_duration_parse_iso_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_temporal_field_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_duration_field_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_normalize_date_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_normalize_time_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_normalize_datetime_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -17,6 +17,8 @@ void gql_in_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 /* Dynamic property lookup on a node/edge by runtime key (Graph7). */
 void gql_node_prop_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_edge_prop_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+/* Static property access on a JSON value of unknown shape (Graph6). */
+void gql_dyn_prop_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 /* Cypher-orderability min()/max() aggregates (step + final). */
 void gql_min_step(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_min_final(sqlite3_context *ctx);

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -14,6 +14,11 @@
 void gql_eq_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_subscript_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_in_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+/* Cypher-orderability min()/max() aggregates (step + final). */
+void gql_min_step(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_min_final(sqlite3_context *ctx);
+void gql_max_step(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_max_final(sqlite3_context *ctx);
 void gql_to_bool_strict_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_to_integer_strict_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_to_float_strict_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -14,6 +14,9 @@
 void gql_eq_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_subscript_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_in_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+/* Dynamic property lookup on a node/edge by runtime key (Graph7). */
+void gql_node_prop_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_edge_prop_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 /* Cypher-orderability min()/max() aggregates (step + final). */
 void gql_min_step(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_min_final(sqlite3_context *ctx);

--- a/src/include/transform/cypher_transform.h
+++ b/src/include/transform/cypher_transform.h
@@ -51,6 +51,7 @@ struct cypher_transform_context {
     int unwind_cte_counter;         /* Counter for UNWIND CTE names (_unwind_N) */
     int reduce_counter;             /* Counter for REDUCE CTE names (_reduce_N) */
     int prop_join_counter;          /* Counter for property JOIN aliases */
+    int quantifier_counter;         /* Counter for list-predicate json_each aliases (_je_N) */
     int anon_node_counter;          /* Cumulative counter for anonymous nodes */
     int anon_node_base;             /* Base offset for the current pattern's anon nodes */
 

--- a/src/include/transform/transform_helpers.h
+++ b/src/include/transform/transform_helpers.h
@@ -30,4 +30,10 @@ bool has_labels(cypher_node_pattern *node);
  * keyword. Returns `buf`. Always populates `buf` (raw name or "name"). */
 const char *sql_ident(char *buf, size_t buflen, const char *name);
 
+/* True if `expr` evaluates to a Cypher boolean (comparison, AND/OR/NOT/XOR,
+ * IS NULL, quantifier, EXISTS, boolean literal). Used to wrap projections in
+ * _gql_bool_str so the result renders as a JSON boolean. Defined in
+ * transform_return.c. */
+bool ast_yields_boolean(ast_node *expr);
+
 #endif /* TRANSFORM_HELPERS_H */

--- a/src/include/transform/transform_variables.h
+++ b/src/include/transform/transform_variables.h
@@ -57,6 +57,12 @@ struct transform_var {
 
     /* For projected variables */
     char *source_expr;       /* Original expression (for WITH aliasing) */
+
+    /* T-0333 (Unwind1 [12]): when this projected var holds a list-of-nodes
+     * or list-of-edges (e.g. `collect(n) AS bees`), record the inner kind
+     * so a subsequent UNWIND can re-bind elements as nodes/edges instead
+     * of opaque projected scalars. VAR_KIND_PROJECTED = "unknown / scalar". */
+    var_kind list_inner_kind;
 };
 
 /* Variable context - manages all variables during transformation */

--- a/src/include/transform/transform_variables.h
+++ b/src/include/transform/transform_variables.h
@@ -26,7 +26,8 @@ typedef enum {
 typedef enum {
     VAR_PATH_NORMAL,        /* Regular path matching */
     VAR_PATH_SHORTEST,      /* shortestPath() - single shortest path */
-    VAR_PATH_ALL_SHORTEST   /* allShortestPaths() - all paths of minimum length */
+    VAR_PATH_ALL_SHORTEST,  /* allShortestPaths() - all paths of minimum length */
+    VAR_PATH_COMPREHENSION  /* T-0332: emits fully hydrated path JSON for use inside json_group_array */
 } var_path_type;
 
 /* Unified variable structure */


### PR DESCRIPTION
## Summary
Three Phase-B I-0044 fixes bundled on one branch.

### T-0331 — Cross-type ordered comparison nulls (+4 TCK)
`_gql_order_cmp` returns null for mixed scalar text↔numeric per Cypher spec (Comparison2 [3], [6]). Stringified-boolean carve-out (`'true'`/`'false'` → 1/0) preserves Precedence1 [23]/[26].

### T-0332 — Pattern comprehension path-assignment + hydration (+7 TCK)
Pattern2 1/11 → 8/11.
- Rel variable registration in comprehension scope (fixes [5]).
- Grammar productions for `[p = pattern | expr]` and the `WHERE` variant (`%expect` 14 → 15).
- AST `cypher_pattern_comprehension.path_var`.
- New `VAR_PATH_COMPREHENSION` path type: when the comprehension references the path variable, emit fully-hydrated path JSON (`{nodes:[...], rels:[...]}`) inline so it survives nested inside `json_group_array` aggregates without executor list-element post-processing.

Remaining 3 Pattern2 fails ([7] nested comp scoping, [8] WITH grouping, [11] undirected reverse) are independent issues.

### T-0333 — RETURN * picks up source_expr for projected vars (+2 TCK)
`RETURN *` was passing `var->table_alias` directly to `sql_select`. For VAR_KIND_PROJECTED (UNWIND alias, WITH-carried vars) that's NULL; the column reference lives on `source_expr`. Route through `transform_var_get_alias` so the column lands in SELECT with the user-bound name (Unwind1 [11]/[13]).

## TCK
3573 → 3586 (+13). Zero regressions.

## Test plan
- [x] `angreal test unit` (944/944)
- [x] `angreal test functional` (clean)
- [x] `angreal test tck` (clean diff)