### PR TITLE
I-0047 Pattern & Path Matching Completeness (+14 TCK)

### DIFF
--- a/.metis/backlog/bugs/GQLITE-T-0339.md
+++ b/.metis/backlog/bugs/GQLITE-T-0339.md
@@ -1,0 +1,75 @@
+---
+id: match-create-first-row-only
+level: task
+title: "MATCH+CREATE only processes the first matched row"
+short_code: "GQLITE-T-0339"
+created_at: 2026-05-27T00:00:00.000000+00:00
+updated_at: 2026-05-27T00:00:00.000000+00:00
+archived: false
+tags:
+  - "#task"
+  - "#phase/backlog"
+exit_criteria_met: false
+backlog_category: bug
+initiative_id: NULL
+---
+
+# MATCH+CREATE only processes the first matched row
+
+## Objective
+
+Fix the write-path so `MATCH (x) ... CREATE (...)` executes the CREATE **once
+per matched row**, not just for the first match — and so a subsequent CREATE
+clause that references variables created by an earlier CREATE clause fires per
+row too.
+
+## Backlog Item Details
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P1 - High (blocks correct write semantics and several TCK setups)
+
+### Impact Assessment
+- **Affected scenarios**: Any `MATCH … CREATE …` over a multi-row match. Blocks
+  the setup of Match5 [25]/[26]/[28]/[29] and Match4 [4] (so they read 0 rows),
+  and likely more across the suite.
+- **Reproduction** (3 `:D` nodes in the graph):
+  1. `MATCH (d:D) CREATE (e:E {name: d.name})` → `nodes_created = 1` (expect 3).
+  2. `MATCH (d:D) CREATE (d)-[:LIKES]->(x:X)` → `nc=1 rc=1` (expect 3, 3).
+  3. `MATCH (d:D) CREATE (g:G {name:d.name}) CREATE (d)-[:HAS]->(g)`
+     → `nc=1 rc=0` (expect 3, 3).
+- **Expected vs actual**: CREATE should iterate every MATCH row; instead only
+  the first row's CREATE runs. The second CREATE clause (relationship between a
+  matched node and a first-clause-created node) creates **0** relationships.
+
+### Root cause (suspected)
+
+`execute_match_create_query` / `handle_match_create` appears to bind a single
+match row (or take the first) and run CREATE once, rather than looping over all
+match rows. The two-CREATE-clause rel=0 case suggests the second clause doesn't
+see the per-row binding of the first clause's new variables.
+
+## Acceptance Criteria
+
+- [ ] `MATCH (d:D) CREATE (e:E)` creates one node per matched `d`.
+- [ ] `MATCH (d:D) CREATE (d)-[:R]->(x)` creates one rel + node per matched `d`.
+- [ ] Multi-CREATE-clause (`CREATE (g) CREATE (d)-[:R]->(g)`) fires per row,
+  with the second clause seeing the first clause's new bindings.
+- [ ] Zero TCK regressions; unit + functional clean.
+- [ ] Re-run Match5 [25]/[26]/[28]/[29] and Match4 [4] (should unblock; verify).
+
+## Implementation Notes
+
+Discovered during I-0047 P2 ([[GQLITE-T-0335]]) — the Match5 multi-segment
+varlen failures turned out to be this setup bug, not path matching (varlen
+chains match correctly). This is a write-path concern, intentionally kept out
+of I-0047 (Pattern & Path Matching Completeness). Candidate home: a CREATE/
+write-semantics initiative, or promote standalone.
+
+## Status Updates
+
+### 2026-05-27 — Filed from I-0047 P2 investigation
+
+Characterized via execution harness (see [[GQLITE-T-0335]] status notes).

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -186,6 +186,15 @@ refactor (non-destructive consumed-marker, or deep-copy patterns in
 P3/P5 deeper refactors now clearly enumerated as follow-ups; no further TCK
 movement this round (net stays +12, zero regressions).
 
+### 2026-05-27 — P4 ([[GQLITE-T-0337]]) partial: path-through-WITH (+1, session +13)
+
+`MATCH p=… WITH p RETURN p` (With1 [4]) now forwards the path across WITH:
+WITH emits the path-hydration SQL and re-registers `p` as a path var on the CTE
+column; RETURN/executor hydrate it. Tightly scoped (path-through-WITH only),
+**zero regressions** (rigorous pass-set diff), unit 944/944, functional clean.
+Match9 [9] (OPTIONAL varlen named path → null) remains. **Session total: +13
+(3684 → 3697).**
+
 ### 2026-05-27 — P2 (T-0335) completed; premise corrected
 
 Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Pattern & Path Matching Completeness"
 short_code: "GQLITE-I-0047"
 created_at: 2026-05-27T02:26:42.947075+00:00
-updated_at: 2026-05-27T02:26:42.947075+00:00
+updated_at: 2026-05-27T02:51:33.491805+00:00
 parent: GQLITE-V-0001
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -110,6 +110,14 @@ Decompose at pickup. Suggested tasks (roughly independent):
 3. **T: Multi-rel OPTIONAL combined-EXISTS** (P3).
 4. **T: Path variable through WITH / OPTIONAL null** (P4).
 5. **T: MATCH+MERGE re-match property preservation** (P5).
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -155,3 +155,18 @@ OPTIONAL), [[GQLITE-T-0337]] (P4 path-through-WITH / OPTIONAL null),
 
 Match6 [14] (multi-segment fixed+varlen named path) reassigned to P2; Match6
 [17] (zero-length named path) to P4. Remaining: P2/P3/P4/P5 still todo.
+
+### 2026-05-27 — P2 (T-0335) completed; premise corrected
+
+Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen
+chains already match correctly** (verified on clean graphs). The Match5
+[25]/[26]/[28]/[29] failures are a **MATCH+CREATE write-path bug** (only the
+first matched row's CREATE runs) — filed as backlog [[GQLITE-T-0339]], out of
+this initiative's pattern-matching scope; that cluster + Match4 [4] are blocked
+on it.
+
+The genuine in-scope P2 fix landed: `generate_varlen_cte` now applies inline
+**relationship property predicates** (`[:T* {k:v}]`) to every edge in the path.
+**+1** (Match4 [5]), zero regressions, 3690 → **3691**. Match4 [7] (bound rel in
+multi-varlen path) and [8] (`-[rs*]->` bound rel-list) deferred as niche varlen
+features. Session running total for I-0047: **+7**.

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -156,6 +156,22 @@ OPTIONAL), [[GQLITE-T-0337]] (P4 path-through-WITH / OPTIONAL null),
 Match6 [14] (multi-segment fixed+varlen named path) reassigned to P2; Match6
 [17] (zero-length named path) to P4. Remaining: P2/P3/P4/P5 still todo.
 
+### 2026-05-27 — P2 done (+1), P3 substantial progress (+5); session +12
+
+- **P2 ([[GQLITE-T-0335]], done):** varlen relationship property predicate
+  (Match4 [5]). Disproved the multi-segment premise (chains already match);
+  filed MATCH+CREATE first-row-only write-path bug as [[GQLITE-T-0339]].
+- **P3 ([[GQLITE-T-0336]], partial +5):** OPTIONAL row-preservation (Match7
+  [15], Aggregation5 [2]); varlen relationship-uniqueness (Match7 [12]);
+  null-guard for WITH-projected NULL node/edge in RETURN (Match7 [21], [27]).
+  Match7 now 30/31. Remaining: bound-rel reverse OPTIONAL (Match7 [4],
+  MatchWhere6 [5] — needs deferred-constraint plumbing) and MatchWhere6 [7]
+  (multi-rel combined-EXISTS → derived-table rewrite).
+
+**Session total: 3684 → 3696 (+12), zero regressions, unit 944/944, functional
+clean.** Branch `i0047-pattern-path`. Still todo: P4 ([[GQLITE-T-0337]]),
+P5 ([[GQLITE-T-0338]]), the two deferred P3 refactors, and [[GQLITE-T-0339]].
+
 ### 2026-05-27 — P2 (T-0335) completed; premise corrected
 
 Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -195,6 +195,15 @@ column; RETURN/executor hydrate it. Tightly scoped (path-through-WITH only),
 Match9 [9] (OPTIONAL varlen named path → null) remains. **Session total: +13
 (3684 → 3697).**
 
+### 2026-05-27 — P4 ([[GQLITE-T-0337]]) COMPLETE: +2 (session +14)
+
+Match9 [9] also fixed: the OPTIONAL varlen relationship list returned `[]`
+instead of NULL on a no-match (`json_group_array` over `json_each(NULL)` yields
+`'[]'`); wrapped in a `CASE WHEN elem_ids IS NULL` guard. P4 done (With1 [4] +
+Match9 [9]), zero regressions. **Session total: +14 (3684 → 3698).** Remaining
+deferred refactors: P3 bound-rel-reverse, P3 multi-rel combined-EXISTS, P5
+(AST-mutation/SET), and write-path [[GQLITE-T-0339]].
+
 ### 2026-05-27 — P2 (T-0335) completed; premise corrected
 
 Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -135,3 +135,23 @@ Decompose at pickup. Suggested tasks (roughly independent):
 Filed from the I-0044 push (94.9%). Discovery phase. Contained pattern/path
 wins already landed under I-0044; this owns the structural CTE + OPTIONAL +
 combined-pattern remainder. Awaiting human review before decomposition.
+
+### 2026-05-27 — Decomposed and P1 (T-0334) completed
+
+Human-approved decomposition into [[GQLITE-T-0334]] (P1 undirected varlen),
+[[GQLITE-T-0335]] (P2 multi-segment chains), [[GQLITE-T-0336]] (P3 multi-rel
+OPTIONAL), [[GQLITE-T-0337]] (P4 path-through-WITH / OPTIONAL null),
+[[GQLITE-T-0338]] (P5 MATCH+MERGE re-match). Work on branch
+`i0047-pattern-path`.
+
+**P1 (T-0334) COMPLETE — +6 TCK, zero regressions** (3684 → 3690):
+- Undirected varlen now traverses both edge orientations in the top-level MATCH
+  CTE (`generate_varlen_cte`) → Match9 [1]/[3].
+- `count(*)` in MATCH+DELETE decoupled from the accumulated delete-count
+  coincidence (`handle_match_delete` pre-captures the live MATCH) → Delete4 [1]
+  fixed, Delete4 [2] canary held at 6 (the prior reverted attempt's 12 avoided).
+- Varlen inside WHERE existential pattern predicates (`emit_exists_varlen_path`,
+  endpoint labels honored) → Pattern1 [10]/[17]/[18].
+
+Match6 [14] (multi-segment fixed+varlen named path) reassigned to P2; Match6
+[17] (zero-length named path) to P4. Remaining: P2/P3/P4/P5 still todo.

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -204,6 +204,22 @@ Match9 [9]), zero regressions. **Session total: +14 (3684 → 3698).** Remaining
 deferred refactors: P3 bound-rel-reverse, P3 multi-rel combined-EXISTS, P5
 (AST-mutation/SET), and write-path [[GQLITE-T-0339]].
 
+### 2026-05-28 — Branch pushed; P3 bound-rel reverse FIXED on top (+1, session +15)
+
+Branch `i0047-pattern-path` pushed; **PR #76** opened. The earlier +14 push is
+fully green on CI (build-and-test, coverage gate, all platforms × Python
+matrix, Rust, Windows, tck-conformance).
+
+On top, the bound-rel reverse OPTIONAL (Match7 [4]) landed via a deferred-flush
+mechanism: a new `ctx->pending_optional_on` stash + a flush onto the last LEFT
+JOIN's ON after the path loop, guarded to fire only when exactly one endpoint
+is in outer scope. **+1, zero regressions** (full pass-set diff vs HEAD). 3698 →
+**3699**.
+
+**Session total: +15 (3684 → 3699).** Remaining deferred: MatchWhere6 [5]/[7]
+(both-endpoints-fresh / multi-rel combined-EXISTS → derived-table rewrite); P5;
+T-0339.
+
 ### 2026-05-27 — P2 (T-0335) completed; premise corrected
 
 Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen

--- a/.metis/initiatives/GQLITE-I-0047/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0047/initiative.md
@@ -172,6 +172,20 @@ Match6 [14] (multi-segment fixed+varlen named path) reassigned to P2; Match6
 clean.** Branch `i0047-pattern-path`. Still todo: P4 ([[GQLITE-T-0337]]),
 P5 ([[GQLITE-T-0338]]), the two deferred P3 refactors, and [[GQLITE-T-0339]].
 
+### 2026-05-27 — P5 ([[GQLITE-T-0338]]) root-caused; deferred (AST-mutation/SET entanglement)
+
+Merge5 [12]/[13] (undirected MERGE re-match doubling) traced to an **AST
+mutation gotcha**: `generate_node_match` nulls `first_pair->key` to mark an
+inline property consumed, so the MATCH+MERGE RETURN re-match (which
+re-transforms the same AST) loses the `{id:…}` filters → undirected double
+match. The "stop mutating" fix works (+2) but **regresses Set4/Set5** (the SET
+path depends on the same mutation). Proper fix = a coordinated transform
+refactor (non-destructive consumed-marker, or deep-copy patterns in
+`handle_match_merge`). Deferred with full analysis in the task.
+
+P3/P5 deeper refactors now clearly enumerated as follow-ups; no further TCK
+movement this round (net stays +12, zero regressions).
+
 ### 2026-05-27 — P2 (T-0335) completed; premise corrected
 
 Investigation overturned P2's premise: **multi-segment / mixed fixed+varlen

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
@@ -173,3 +173,34 @@ distinct, non-trivial sub-feature separate from the top-level MATCH CTE just
 landed. Scoped as the next P1 sub-task (this emitter is also where undirected
 fixed predicates already work, so the bidirectional logic can be shared). Not
 attempted in this increment.
+
+### 2026-05-27 — EXISTS-predicate varlen landed; +3 more, zero regressions
+
+Added `emit_exists_varlen_path` (`transform_expr_predicate.c`): a guarded branch
+in the `AST_NODE_PATH` EXISTS emitter that handles the `[node, varlen-rel, node]`
+shape with an inline correlated recursive CTE
+(`EXISTS (WITH RECURSIVE _epv_N(start_id, end_id, depth, visited) AS (…)
+SELECT 1 … WHERE start_id = <left>.id [AND end_id = <right>.id] AND depth
+BETWEEN min AND max)`). Same bidirectional traversal as the MATCH CTE
+(directed honors arrows; undirected walks both orientations; node-based cycle
+prevention). The left endpoint must be outer-bound to correlate; the right is
+bound when it's an outer var, else free (the `(n)-[*]-()` anon case).
+
+Endpoint **label** constraints are honored against the CTE's start/end ids
+(`(a)-[:T*]->(b:MissingLabel)`); inline endpoint **properties** bail to the
+legacy emitter (unchanged pre-existing behavior, no new regression).
+
+First pass regressed MatchWhere4 [2] / WithWhere4 [2] ("disjunctive multi-part
+predicates including patterns") because the helper ignored the `:MissingLabel`
+endpoint label → the EXISTS wrongly matched. Adding endpoint-label handling
+fixed both back to passing.
+
+**Verification:** full TCK pass-set diff vs. the P1-core baseline →
+newly passing Pattern1 [10]/[17]/[18], **zero regressions**. 3687 → **3690**.
+Unit 944/944, functional clean.
+
+**P1 status:** undirected varlen now correct in both the top-level MATCH CTE
+and WHERE EXISTS-pattern predicates. Session total for T-0334: **+6**
+(Match9 [1]/[3], Delete4 [1], Pattern1 [10]/[17]/[18]). Remaining acceptance
+items (Match6 [14] multi-segment, Match6 [17] zero-length named path) belong to
+P2 ([[GQLITE-T-0335]]) / P4 ([[GQLITE-T-0337]]).

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
@@ -4,14 +4,14 @@ level: task
 title: "P1: Undirected variable-length paths (CTE + outer endpoint)"
 short_code: "GQLITE-T-0334"
 created_at: 2026-05-27T02:49:29.588563+00:00
-updated_at: 2026-05-27T02:51:36.061364+00:00
+updated_at: 2026-05-27T12:26:59.280587+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -40,11 +40,15 @@ Target scenarios: **Match9 [1]/[3], Match6 [14], Pattern1 [10]/[17]/[18]**
 
 ## Acceptance Criteria
 
-- [ ] Match9 [1]/[3], Match6 [14], Pattern1 [10]/[17]/[18] move to pass.
-- [ ] **Delete4 [2] stays passing** (the undirected-varlen double-count canary).
-- [ ] Zero TCK regressions (full pass-set diff); unit 944/944; functional clean.
-- [ ] A functional regression test covers an undirected `-[*]-` round-trip.
-- [ ] TCK delta logged in Status Updates and rolled up to [[GQLITE-I-0047]].
+- [x] Match9 [1]/[3] and Pattern1 [10]/[17]/[18] move to pass. (Match6 [14]
+  reassigned to P2/[[GQLITE-T-0335]] — multi-segment named path, distinct.)
+- [x] **Delete4 [2] stays passing** (the undirected-varlen double-count canary);
+  Delete4 [1] also fixed as a bonus.
+- [x] Zero TCK regressions (full pass-set diff); unit 944/944; functional clean.
+- [~] Functional regression coverage: the functional harness is execution-only
+  (no output assertions), so the undirected `-[*]-` round-trip is recorded in
+  `docs/testing/semantic-coverage-matrix.md` and gated by the TCK suite instead.
+- [x] TCK delta logged in Status Updates and rolled up to [[GQLITE-I-0047]].
 
 ## Implementation Notes
 

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
@@ -1,0 +1,159 @@
+---
+id: p1-undirected-variable-length
+level: task
+title: "P1: Undirected variable-length paths (CTE + outer endpoint)"
+short_code: "GQLITE-T-0334"
+created_at: 2026-05-27T02:49:29.588563+00:00
+updated_at: 2026-05-27T02:51:36.061364+00:00
+parent: GQLITE-I-0047
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0047
+---
+
+# P1: Undirected variable-length paths (CTE + outer endpoint)
+
+## Parent Initiative
+
+[[GQLITE-I-0047]]
+
+## Objective
+
+Make undirected variable-length patterns (`-[r*]-`) traverse **both** edge
+orientations without double-counting result rows. The variable-length
+recursive CTE (`cypher_transform.c::generate_varlen_cte`) currently only walks
+`source_id → target_id`, so `(a)-[*0..1]-(b)` misses reverse hops and returns
+too few rows. A prior I-0044 attempt made the CTE bidirectional but the *outer*
+undirected endpoint matching then double-counted, regressing **Delete4 [2]**
+(reverted). The CTE traversal and the outer endpoint-pattern emission must be
+changed **together** and deduped against each other.
+
+Target scenarios: **Match9 [1]/[3], Match6 [14], Pattern1 [10]/[17]/[18]**
+(~6 scenarios).
+
+## Acceptance Criteria
+
+- [ ] Match9 [1]/[3], Match6 [14], Pattern1 [10]/[17]/[18] move to pass.
+- [ ] **Delete4 [2] stays passing** (the undirected-varlen double-count canary).
+- [ ] Zero TCK regressions (full pass-set diff); unit 944/944; functional clean.
+- [ ] A functional regression test covers an undirected `-[*]-` round-trip.
+- [ ] TCK delta logged in Status Updates and rolled up to [[GQLITE-I-0047]].
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Reproduce: isolate the failing scenarios with
+   `angreal test tck --filter Match9` (and Match6/Pattern1) to capture the
+   exact row-count deltas before any change.
+2. Make `generate_varlen_cte` traverse both orientations for undirected rels
+   — UNION the `source_id→target_id` and `target_id→source_id` seed/step, and
+   in the recursive step match on `e.source_id = frontier OR e.target_id =
+   frontier`, carrying the "other endpoint" forward.
+3. Simultaneously fix the **outer** endpoint-pattern emission so the
+   undirected endpoints are matched once, not once per orientation — dedupe
+   the CTE rows against the outer pattern (likely a `DISTINCT` keyed on the
+   path's elem_ids, or an orientation-canonicalization in the CTE so each
+   undirected walk is emitted in one canonical direction).
+4. Only apply bidirectional logic when the rel pattern is undirected; leave
+   directed varlen untouched.
+
+### Dependencies
+
+Builds on the single-varlen `elem_ids` hydration column landed in I-0044.
+Independent of P2–P5.
+
+### Risk Considerations
+
+The prior reverted attempt proves the CTE and outer emission are coupled: a
+correct CTE with a naive outer match double-counts. Verify Delete4 [2] on
+*every* iteration, not just at the end. Run `angreal dev clean` if any
+function signature in the CTE generator changes.
+
+## Status Updates
+
+### 2026-05-27 — Root cause confirmed; P1 is entangled with a documented count(*) hack
+
+Reproduced and traced via a throwaway SQL-dump + execution harness (built
+against `*.cov.o`, since the TCK harness doesn't surface generated SQL).
+
+**Confirmed root cause (CTE side):** `generate_varlen_cte`
+(`cypher_transform.c:1173`) only handles `left_arrow` reversal; **undirected**
+(`!left_arrow && !right_arrow`) falls through to the default
+`source_id → target_id` single orientation. So `MATCH (a)-[*]-(b)` over
+`(1)-[:R]->(2)-[:R]->(3)` yields only the 3 directed rows `(1,2),(1,3),(2,3)`;
+real Cypher wants 6 (both orientations). Match9 [1]'s missing `(b,a)` row is the
+same defect. The outer endpoint binding is strictly directional
+(`cte.start_id = a.id AND cte.end_id = b.id`, **no** OR) — so making the CTE
+bidirectional and leaving the outer binding directional is the correct single
+fix for the *match* count (verified by hand against Match9 [1]/[3]).
+
+**The Delete4 [2] entanglement (the canary):**
+`MATCH (a)-[*]-(b) DETACH DELETE a,b RETURN count(*)` expects **6** and
+**passes today — by coincidence, not correctness.** With the directed CTE the
+MATCH yields 3 rows. `handle_match_delete` (`query_dispatch.c:797`) routes
+`count(*)` through `synthesize_delete_return`, which returns the *accumulated
+delete count*: `execute_match_delete_query` increments `deleted_nodes` once per
+(row × delete-var) with **no dedup** → 3 rows × 2 endpoints = 6. The dispatch
+comment (lines 810-818) explicitly documents this: the delete count
+"by historical coincidence" matches expected aggregates "for shapes our MATCH
+undercounts (e.g. undirected varlen). Pre-MATCHing those would regress them."
+
+**Consequence:** fixing the CTE → 6 match rows → `synthesize_delete_return`
+would report 6 × 2 = **12**, regressing Delete4 [2]. This is exactly the prior
+reverted attempt's failure mode.
+
+**Therefore P1 requires TWO coordinated changes:**
+1. Bidirectional undirected varlen CTE (base case UNIONs both orientations;
+   recursive step extends on `source_id = end OR target_id = end` carrying the
+   other endpoint forward; cycle-prevention + elem_ids use the chosen endpoint).
+2. Decouple `count(*)`/literal RETURN in MATCH+DELETE from the delete-count
+   coincidence — pre-MATCH the RETURN (incl. count) against the now-correct
+   match instead of `synthesize_delete_return`. **Risk:** the hack also covers
+   *other* shapes our MATCH still undercounts; removing it could regress those
+   unless their MATCH is also correct. Needs the full-suite diff to bound.
+
+**Scope decision pending with human** (see initiative): full two-part P1 fix
+(A: CTE + B: decouple delete-count), vs. land A behind a narrower guard, vs.
+reorder to a lower-risk cluster (P5/P3) first.
+
+### 2026-05-27 — Parts A + B implemented; +3, zero regressions
+
+Human chose the full two-part fix. Both landed:
+
+- **Part A** (`cypher_transform.c` `generate_varlen_cte`): added an
+  `undirected` branch. Base case UNIONs the reverse orientation; recursive step
+  joins `e.source_id = cte.end_id OR e.target_id = cte.end_id` and advances to
+  the edge's *other* endpoint via a `CASE` expr (used consistently for end_id,
+  path_ids, visited, elem_ids, and node-based cycle prevention). Directed varlen
+  is untouched. Also refactored the rel-type predicate into one reusable
+  `tpred` buffer (was inlined 2×; now 3 use sites).
+- **Part B** (`query_dispatch.c` `handle_match_delete`): `count()` now triggers
+  the pre-delete MATCH pre-capture instead of `synthesize_delete_return`, so
+  `count(*)` reflects matched rows, not the (un-deduped) delete count. Literal
+  RETURNs still use synthesize. Comment updated to document the rationale.
+
+**Verification (full TCK pass-set diff vs. pre-change baseline of 3684):**
+- Newly passing: Match9 [1], Match9 [3], **Delete4 [1]** (single-hop undirected
+  `count(*)`, a bonus from Part B).
+- **Regressed: none.** Delete4 [2] (the canary) stays correct (6, not 12).
+- Total: 3684 → **3687 (+3)**. Unit 944/944, functional clean.
+
+**Not fixed (distinct generators, deferred):**
+- Pattern1 [10]/[17]/[18] — undirected varlen inside WHERE `EXISTS`-pattern
+  predicates (`MATCH (n) WHERE (n)-[:REL1*2]-()`). Different code path than the
+  top-level MATCH CTE; needs the pattern-predicate emitter taught the same
+  bidirectional logic. Tracked here as P1 residual.
+- Match6 [14] (multi-segment undirected fixed+varlen named path → P2 /
+  [[GQLITE-T-0335]]) and Match6 [17] (zero-length named path hydration → P4 /
+  [[GQLITE-T-0337]]).
+
+Committing the +3 verified increment; P1 residual (EXISTS-predicate varlen)
+continues next on the same branch.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0334.md
@@ -157,3 +157,19 @@ Human chose the full two-part fix. Both landed:
 
 Committing the +3 verified increment; P1 residual (EXISTS-predicate varlen)
 continues next on the same branch.
+
+### 2026-05-27 — P1 residual scoped: varlen in WHERE EXISTS-pattern predicates
+
+Traced Pattern1 [10]/[17]/[18]. The WHERE pattern-predicate emitter
+(`transform_expr_predicate.c:51+`, the `AST_NODE_PATH` EXISTS branch) only
+handles **fixed single-hop** relationships: it emits one `edges AS eN` table
+per rel and joins `eN.source_id/target_id` to the node aliases, with **no
+handling of `rel->varlen`**. So `MATCH (n) WHERE (n)-[:REL1*2]-()` collapses the
+`*2` to a single REL1 edge match → returns A,B,D instead of B,D.
+
+Fixing this means emitting (or referencing) a recursive varlen CTE *inside* the
+EXISTS subquery and binding the outer node to its `start_id`/`end_id` — a
+distinct, non-trivial sub-feature separate from the top-level MATCH CTE just
+landed. Scoped as the next P1 sub-task (this emitter is also where undirected
+fixed predicates already work, so the bidirectional logic can be shared). Not
+attempted in this increment.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0335.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0335.md
@@ -1,0 +1,69 @@
+---
+id: p2-multi-segment-mixed-fixed
+level: task
+title: "P2: Multi-segment / mixed fixed+varlen path chains"
+short_code: "GQLITE-T-0335"
+created_at: 2026-05-27T02:49:32.608411+00:00
+updated_at: 2026-05-27T02:49:32.608411+00:00
+parent: GQLITE-I-0047
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0047
+---
+
+# P2: Multi-segment / mixed fixed+varlen path chains
+
+## Parent Initiative
+
+[[GQLITE-I-0047]]
+
+## Objective
+
+Stitch multi-segment paths that combine a variable-length rel with a fixed
+rel, or chain two variable-length segments in one path
+(`(a)-[*]->(b)-[r]->(c)`, `(a)-[*]->(b)-[*]->(c)`). These currently return
+empty or wrong rows because the single-varlen `elem_ids` hydration (I-0044)
+handles only one segment.
+
+Target scenarios: **Match5 [25]/[26]/[28], Match4 [4]/[5], Match6 [17]**.
+Note **Match4 [4]'s** failure is actually in its *setup* (CREATE rels between
+list-subscript nodes) — a write-path dependency that may need to split out.
+
+## Acceptance Criteria
+
+- [ ] Match5 [25]/[26]/[28], Match6 [17], Match4 [5] move to pass.
+- [ ] Match4 [4] either passes or its write-path blocker is filed separately.
+- [ ] Zero TCK regressions; unit 944/944; functional clean.
+- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+
+## Implementation Notes
+
+### Technical Approach
+
+Each path segment generates its own CTE/join fragment. The stitch point is the
+shared intermediate node variable (`b` above): the fixed-rel join's endpoint
+must bind to the varlen CTE's terminal node, and the varlen `elem_ids` must be
+concatenated across segments for named-path hydration. Likely changes in
+`transform_match.c` segment iteration + the varlen CTE wiring in
+`cypher_transform.c`.
+
+### Dependencies
+
+Builds on P1 ([[GQLITE-T-0334]]) for the corrected varlen CTE shape; best
+sequenced after P1 lands. Match4 [4] has a CREATE write-path prerequisite.
+
+### Risk Considerations
+
+Two varlen segments multiply CTE cost; watch for combinatorial row blowup.
+Run `angreal dev clean` after CTE-generator signature changes.
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0335.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0335.md
@@ -4,14 +4,14 @@ level: task
 title: "P2: Multi-segment / mixed fixed+varlen path chains"
 short_code: "GQLITE-T-0335"
 created_at: 2026-05-27T02:49:32.608411+00:00
-updated_at: 2026-05-27T02:49:32.608411+00:00
+updated_at: 2026-05-27T13:48:20.861582+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -38,10 +38,19 @@ list-subscript nodes) — a write-path dependency that may need to split out.
 
 ## Acceptance Criteria
 
-- [ ] Match5 [25]/[26]/[28], Match6 [17], Match4 [5] move to pass.
-- [ ] Match4 [4] either passes or its write-path blocker is filed separately.
-- [ ] Zero TCK regressions; unit 944/944; functional clean.
-- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+## Acceptance Criteria
+
+- [x] **Match4 [5]** (varlen rel property predicate `{year:1988}`) moves to pass
+  — the genuine in-scope P2 matching bug.
+- [x] Match4 [4] write-path blocker filed separately ([[GQLITE-T-0339]]).
+- [~] Match5 [25]/[26]/[28]/[29]: **not** a multi-segment varlen bug (those
+  match correctly); blocked by the MATCH+CREATE setup bug [[GQLITE-T-0339]].
+  Will pass once T-0339 lands; re-verify then.
+- [~] Match4 [7] (bound rel inside multi-varlen path; `ambiguous column`
+  SQL-gen error) and Match4 [8] (`-[rs*]->` over a bound rel-list) are niche
+  varlen features deferred — distinct from multi-segment chains.
+- [x] Zero TCK regressions; unit 944/944; functional clean.
+- [x] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
 
 ## Implementation Notes
 
@@ -66,4 +75,58 @@ Run `angreal dev clean` after CTE-generator signature changes.
 
 ## Status Updates
 
-*To be added during implementation*
+### 2026-05-27 — P2 premise corrected: multi-segment varlen already works
+
+Investigated the target cluster with the SQL-dump + execution harness. Key
+finding: **multi-segment / mixed fixed+varlen chains already match correctly.**
+On a clean linear graph `(:A)-[:LIKES]->(:B)-[:LIKES]->(:C)-[:LIKES]->(:D)-[:LIKES]->(:E)`:
+- `(a:A)-[:LIKES]->()-[:LIKES*3]->(c)` → `e` ✓
+- `(a:A)-[:LIKES]->(x)-[:LIKES*2]->(c)` → `(b, d)` ✓
+The generated SQL stitches the fixed segment's target to the varlen CTE's
+`start_id` properly. So the original P2 premise (chains not stitched) is wrong.
+
+**Why Match5 [25]/[26]/[28]/[29] fail (0 rows):** their *setup* never builds
+the graph. `MATCH (d:D) CREATE (e1:E {name:d.name+'0'}),(e2:E …) CREATE
+(d)-[:LIKES]->(e1),(d)-[:LIKES]->(e2)` reports `nc=2 rc=0` over 8 D nodes.
+Minimal repro (3 D nodes):
+- `MATCH (d:D) CREATE (e:E {name:d.name})` → nc=**1** (expected 3)
+- `MATCH (d:D) CREATE (d)-[:LIKES]->(x:X)` → nc=1 rc=1 (expected 3,3)
+- `MATCH (d:D) CREATE (g:G) CREATE (d)-[:HAS]->(g)` → nc=1 rc=**0** (expected 3,3)
+
+→ **MATCH+CREATE only processes the FIRST matched row**, and a second CREATE
+clause referencing first-clause vars creates 0 rels. This is a **write-path
+multiplicity bug**, outside I-0047's pattern/path-matching scope. Filed as a
+backlog item; Match5 [25]/[26]/[28]/[29] and Match4 [4] are blocked on it.
+
+**Genuine in-scope P2 work (relationship predicates on varlen):**
+- **Match4 [5]** `(a)-[:WORKED_WITH* {year:1988}]->(b)` → returns 3, expected 1.
+  The varlen CTE ignores the rel **property predicate** `{year:1988}` (only
+  b→c has year 1988). `generate_varlen_cte` must filter edges by inline rel
+  properties in base + recursive steps.
+- **Match4 [8]** similar (relationships-into-list + varlen rel-prop filter).
+- **Match4 [7]** errors `ambiguous column name: _gql_default_alias_0.source_id`
+  (bound rel + varlen) — a SQL-gen bug to triage separately.
+
+**Plan:** retarget T-0335 to the varlen relationship-property predicate
+(Match4 [5]/[8]); file MATCH+CREATE multiplicity as backlog; re-home the Match5
+cluster behind that backlog item.
+
+### 2026-05-27 — Varlen rel-property predicate landed; +1, zero regressions
+
+Extended `generate_varlen_cte` (`cypher_transform.c`): the per-edge predicate
+buffer (`tpred`, previously type-only) now also folds inline relationship
+property predicates — for each `{k: literal}` pair, an
+`EXISTS (SELECT 1 FROM edge_props_<type> ep JOIN property_keys pk … WHERE
+ep.edge_id = e.id AND pk.key = '<k>' AND ep.value = <v>)` ANDed into the edge
+filter. Applies in the base case (both orientations) and the recursive step, so
+**every** edge along the varlen path must carry the properties (mirrors the
+non-varlen rel-property filter in `transform_match.c:495`).
+
+**Verification:** Match4 [5] (`(a)-[:WORKED_WITH* {year:1988}]->(b)`) now passes
+(was 3 rows, now the 1 correct row). Full TCK pass-set diff: +1, **zero
+regressions**. 3690 → 3691. Unit 944/944, functional clean.
+
+**T-0335 complete for its in-scope deliverable.** Match5 cluster + Match4 [4]
+deferred to [[GQLITE-T-0339]] (MATCH+CREATE write path); Match4 [7]/[8] are
+niche varlen features (bound rel in path / bound rel-list spec), left for a
+follow-up if they surface as priorities.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -4,14 +4,14 @@ level: task
 title: "P3: Multi-rel OPTIONAL MATCH combined-EXISTS join ordering"
 short_code: "GQLITE-T-0336"
 created_at: 2026-05-27T02:49:35.864661+00:00
-updated_at: 2026-05-27T02:49:35.864661+00:00
+updated_at: 2026-05-27T13:49:25.624884+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -34,6 +34,8 @@ combined-EXISTS shape rather than chained LEFT JOINs.
 
 Target scenarios: **MatchWhere6 [5]/[7], Match7, Match4 [7]**. Residual of
 I-0044's B1 (T-0320 / T-0330).
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -1,0 +1,70 @@
+---
+id: p3-multi-rel-optional-match
+level: task
+title: "P3: Multi-rel OPTIONAL MATCH combined-EXISTS join ordering"
+short_code: "GQLITE-T-0336"
+created_at: 2026-05-27T02:49:35.864661+00:00
+updated_at: 2026-05-27T02:49:35.864661+00:00
+parent: GQLITE-I-0047
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0047
+---
+
+# P3: Multi-rel OPTIONAL MATCH combined-EXISTS join ordering
+
+## Parent Initiative
+
+[[GQLITE-I-0047]]
+
+## Objective
+
+Fix `OPTIONAL MATCH (x)-[:E1]->(y)-[:E2]->(z) WHERE ...`, which currently
+errors **"ON clause references tables to its right"** — the emitted LEFT JOIN's
+ON condition references a table that hasn't been joined yet. A multi-rel
+OPTIONAL pattern must be all-or-null as a whole, which calls for a
+combined-EXISTS shape rather than chained LEFT JOINs.
+
+Target scenarios: **MatchWhere6 [5]/[7], Match7, Match4 [7]**. Residual of
+I-0044's B1 (T-0320 / T-0330).
+
+## Acceptance Criteria
+
+- [ ] MatchWhere6 [5]/[7], Match7 and Match4 [7] failing scenarios move to pass.
+- [ ] No "ON clause references tables to its right" errors on multi-rel OPTIONAL.
+- [ ] Single-rel OPTIONAL MATCH semantics unchanged (no regressions).
+- [ ] Zero TCK regressions; unit 944/944; functional clean.
+- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+
+## Implementation Notes
+
+### Technical Approach
+
+The full OPTIONAL pattern should be emitted so its endpoints are null-or-all:
+generate the multi-rel pattern as a single correlated subquery (EXISTS /
+LEFT JOIN against a derived table that materializes the whole pattern), so the
+inner joins resolve their own table ordering and the outer query only sees the
+combined result. This mirrors the combined-EXISTS approach already used for
+single-rel OPTIONAL in I-0044. Changes in the OPTIONAL-MATCH emission path of
+`transform_match.c`.
+
+### Dependencies
+
+Independent of P1/P2. Shares the OPTIONAL emission code with P4's OPTIONAL
+varlen null case — coordinate if both touch the same join builder.
+
+### Risk Considerations
+
+Correlated-subquery rewrite can change result column provenance; verify WHERE
+predicates that reference OPTIONAL-bound vars still null-propagate correctly.
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -100,3 +100,28 @@ execution harness:
   WITH null-var binding issue.
 - **Match7 [12]**: varlen optional row count (exp 4 got 3).
 - **Match7 [27]**: correlated optional between optionally-matched entities.
+
+### 2026-05-27 — Bound-rel reverse OPTIONAL: attempted, reverted (needs deeper change)
+
+Root cause confirmed for Match7 [4] / MatchWhere6 [5]
+(`MATCH (a1)-[r]->() WITH r,a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2)`): the
+bound-rel handler (`transform_match.c`, `rel_is_bound` branch) emits the
+endpoint constraints (`a1 = r.target AND b2 = r.source`) via `sql_where`. For
+OPTIONAL these belong in the fresh target node's LEFT JOIN ON — as WHERE they
+filter the anchor row away (a1=A ≠ r.target=B → 0 rows instead of 1 with b2
+null).
+
+Two attempts to redirect the constraint to the LEFT JOIN ON
+(`sql_join_append_on`) **both regressed** other bound-rel-OPTIONAL shapes
+(Match7 errors): `sql_join_append_on` appends to *the last emitted join*, which
+is not reliably the target node's LEFT JOIN — other shapes (both endpoints
+bound, target bound, or extra joins between) get a malformed `... ON ... AND
+<cond>` tail or attach to the wrong join. Even a narrow guard
+(`src in scope && tgt fresh`, dot-in-alias heuristic) still mis-targeted.
+
+**Conclusion:** the constraint must be emitted *as part of* the target node's
+LEFT JOIN ON at the moment that join is created (e.g. generate_node_match
+returns/accepts a pending-ON, or the bound-rel handler emits the target node
+join itself with the constraint inline), not appended post-hoc. That's a deeper
+plumbing change than a `sql_where`→`append_on` swap. Reverted to preserve the
+clean +9 state; left for a focused follow-up.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -155,3 +155,29 @@ Reverted; needs the deeper deferral plumbing.
 **Remaining (deeper refactors, deferred):** Match7 [4] / MatchWhere6 [5]
 (bound-rel reverse — deferred-constraint plumbing); MatchWhere6 [7]
 (multi-rel combined-EXISTS → derived-table rewrite).
+### 2026-05-28 — Bound-rel reverse OPTIONAL FIXED (+1: Match7 [4])
+
+Reattempted with the **deferred-flush** approach the prior analysis pointed to.
+Added `ctx->pending_optional_on` (header struct field): the bound-rel handler
+stashes its endpoint constraint there for OPTIONAL, and `transform_match_clause`
+flushes it via `sql_join_append_on` after the path loop (so the fresh target
+node's LEFT JOIN exists). Guarded to fire only when **exactly one** endpoint
+is in outer scope and the other is fresh — both-fresh CROSS-multiplies the
+early endpoint (caught Match7 [5] regressing before the guard).
+
+**Verified: +1 (Match7 [4]), zero regressions** (full pass-set diff vs HEAD,
+done by rebuilding HEAD in-place via stash/clean rebuild). Unit 944/944,
+functional clean.
+
+**MatchWhere6 [5] not fixed**: both endpoints fresh (a2, b2) + a WHERE
+correlation `a1 = a2`; the guard correctly skips it (both-fresh case). It
+needs the derived-table approach (same as MatchWhere6 [7]).
+
+Note: adding `pending_optional_on` to the struct required `angreal dev clean`
+(per the project's struct/enum change rule — incremental builds leave stale
+objects with old layout, observed during dev as a catastrophic regression
+recovered with a clean rebuild).
+
+**T-0336 net so far: +6** (Match7 [4]/[12]/[15]/[21]/[27], Aggregation5 [2]).
+Remaining P3: MatchWhere6 [5]/[7] (multi-rel/both-fresh combined-EXISTS →
+derived-table rewrite).

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -125,3 +125,33 @@ returns/accepts a pending-ON, or the bound-rel handler emits the target node
 join itself with the constraint inline), not appended post-hoc. That's a deeper
 plumbing change than a `sql_where`→`append_on` swap. Reverted to preserve the
 clean +9 state; left for a focused follow-up.
+
+### 2026-05-27 — Two more P3 wins (+2 → P3 total +5); bound-rel reverse re-confirmed deferred
+
+3. **Variable-length relationship-uniqueness** (commit eaf19b4) — the varlen
+   CTE's `visited` column tracked node ids and blocked node revisits, but
+   openCypher requires *relationship* uniqueness (each edge once; nodes may
+   repeat). `visited` now tracks edge ids; the cycle predicate forbids reusing
+   an edge. So `(s)-[:REL]->(b)-[:LOOP]->(b)` (two edges, b revisited) is now a
+   valid path. → Match7 [12]. Zero regressions (full diff).
+4. **Null-guard WITH-projected node/edge RETURN projection** (commit cbf0026) —
+   a node/edge bound via OPTIONAL and carried across WITH, when NULL, was
+   projected as `json_object('id', <col>, …)` → a bogus `{id:null,…}` instead
+   of SQL NULL. The `alias_is_id` (post-WITH) projection path lacked the
+   `CASE WHEN id IS NULL THEN NULL` guard the direct-alias path already has.
+   Added it to both node and edge post-WITH projections. → Match7 [21], [27].
+   Zero regressions.
+
+**Bound-rel reverse OPTIONAL — third attempt, reverted again.** Added a *safe*
+guard (redirect to ON only when the joins tail is verifiably the target's
+`LEFT JOIN … AS <tgt> ON 1=1`). It never fires for the failing case because
+the relationship handler runs in the path loop *before* the target node's
+LEFT JOIN is emitted — so at constraint-emission time there is no target join
+to attach to. Confirms the fix must *defer* the bound-rel endpoint constraint
+until the target node join is created (or have that join carry a pending ON).
+Reverted; needs the deeper deferral plumbing.
+
+**P3 net this initiative: +5** (Match7 [12]/[15]/[21]/[27], Aggregation5 [2]).
+**Remaining (deeper refactors, deferred):** Match7 [4] / MatchWhere6 [5]
+(bound-rel reverse — deferred-constraint plumbing); MatchWhere6 [7]
+(multi-rel combined-EXISTS → derived-table rewrite).

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0336.md
@@ -69,4 +69,34 @@ predicates that reference OPTIONAL-bound vars still null-propagate correctly.
 
 ## Status Updates
 
-*To be added during implementation*
+### 2026-05-27 — P3 triage + two OPTIONAL row-preservation fixes (+2)
+
+P3 is several distinct OPTIONAL-MATCH bugs, not one. Triaged via SQL-dump +
+execution harness:
+
+**Landed (+2, zero regressions, 3691 → 3693):**
+1. **OPTIONAL + varlen anchor preservation** (commit 6b45ff7) — for
+   `OPTIONAL MATCH (a)-[:T*]->(c:Label)` with a deferred target, the target
+   label was an INNER `node_labels` join (referencing the not-yet-joined
+   target) and the varlen start/depth constraints landed on it. Now the label
+   folds into the deferred target's LEFT JOIN ON as an EXISTS. → Match7 [15].
+2. **OPTIONAL node labels inline into LEFT JOIN ON** (commit 1b2c218) —
+   `generate_node_match` emitted every non-first OPTIONAL node's label as an
+   INNER join, dropping the anchor row (e.g. a second `OPTIONAL MATCH
+   (b:Missing)`). Now appended to the node's LEFT JOIN ON as EXISTS.
+   → Aggregation5 [2]; unblocks chained-OPTIONAL row preservation generally.
+
+**Remaining P3 (each a distinct, deeper bug — not yet done):**
+- **MatchWhere6 [7]** (the canonical "ON clause references tables to its
+  right"): multi-rel OPTIONAL emits the full-pattern combined-EXISTS onto
+  *each* unbound endpoint's LEFT JOIN, so the first references aliases joined
+  later. Needs a **derived-table** rewrite (LEFT JOIN a subquery that
+  materializes the whole (x,y,z) pattern, keyed to the anchor) — sizable.
+- **Match7 [4]** / **MatchWhere6 [5]**: bound rel `r` reused in a reverse
+  OPTIONAL (`OPTIONAL MATCH (a1)<-[r]-(b2)`) → 0 rows (should preserve a1,r
+  with b2 null).
+- **Match7 [21]**: chained `OPTIONAL…OPTIONAL…WITH…OPTIONAL` now yields the
+  right row count but binds the null vars to node id 0 instead of null — a
+  WITH null-var binding issue.
+- **Match7 [12]**: varlen optional row count (exp 4 got 3).
+- **Match7 [27]**: correlated optional between optionally-matched entities.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
@@ -1,0 +1,70 @@
+---
+id: p4-named-path-through-with
+level: task
+title: "P4: Named path through WITH / OPTIONAL varlen null"
+short_code: "GQLITE-T-0337"
+created_at: 2026-05-27T02:49:38.770497+00:00
+updated_at: 2026-05-27T02:49:38.770497+00:00
+parent: GQLITE-I-0047
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0047
+---
+
+# P4: Named path through WITH / OPTIONAL varlen null
+
+## Parent Initiative
+
+[[GQLITE-I-0047]]
+
+## Objective
+
+Two related path-variable bugs:
+1. **Named path through WITH** — `MATCH p=... WITH p ...` errors
+   **"no such column: p"** because the path variable is not carried through the
+   WITH CTE projection.
+2. **OPTIONAL varlen named path** — an OPTIONAL variable-length named path that
+   doesn't match returns `[]` instead of SQL `null`.
+
+Target scenarios: **With1 [4], Match9 [9]**.
+
+## Acceptance Criteria
+
+- [ ] With1 [4] and Match9 [9] move to pass.
+- [ ] `MATCH p=... WITH p RETURN p` projects the path through the WITH boundary.
+- [ ] OPTIONAL varlen named path with no match returns null, not `[]`.
+- [ ] Zero TCK regressions; unit 944/944; functional clean.
+- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+
+## Implementation Notes
+
+### Technical Approach
+
+The path variable is currently a synthetic column produced during pattern
+hydration but not added to the WITH CTE's projection list. Carry the path's
+backing column(s) (elem_ids + hydration expr) through the WITH projection so
+downstream clauses can reference `p`. For the OPTIONAL-null case, distinguish
+"matched empty path" from "no match" — emit null when the OPTIONAL pattern
+produced no row rather than an empty-list hydration. Changes in
+`transform_with.c` (projection threading) and the path-hydration emission.
+
+### Dependencies
+
+Path hydration shares code with P1/P2's varlen work; sequence after P1 if the
+elem_ids column shape changes. OPTIONAL-null overlaps P3's OPTIONAL emission.
+
+### Risk Considerations
+
+WITH-projection threading is used by many scenarios; a regression here is
+broad. Diff the full WITH-family TCK features specifically.
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
@@ -97,3 +97,30 @@ null) is a further case layered on the same path-through-WITH plumbing plus
 P3's OPTIONAL-null handling.
 
 Left failing; analysis captured for the focused follow-up.
+
+### 2026-05-27 — With1 [4] FIXED (+1); the refactor turned out to be tractable
+
+The path-projection logic already lives in `transform_expression` (the
+`AST_NODE_IDENTIFIER` path branch) — no extraction needed. The real gap was
+that `transform_with.c`'s item loop has its **own** identifier projection that
+bypassed `transform_expression`, so path vars fell through to a bare column.
+
+Implemented:
+- **transform_with.c**: path-var WITH items now emit their hydration SQL (via
+  `transform_expression_to_string`) `AS <col>`. Path metadata (`path_elements`
+  + `path_type`) is preserved across the var-ctx reset (new parallel arrays)
+  and the output is re-registered as a path var whose `table_alias` is the CTE
+  column.
+- **transform_return.c**: the path projection emits that CTE column directly
+  when the path var is projected (`table_alias` contains a `.`) instead of
+  rebuilding from out-of-scope element aliases; the executor still hydrates the
+  stored text into a path object via the preserved `path_elements`.
+
+Scoped tightly: non-path WITH items and non-projected RETURN paths fall through
+unchanged. **Verified: +1 (With1 [4]), zero regressions** (rigorous pass-set
+diff vs HEAD~1), unit 944/944, functional clean. Commit ce… (P4).
+
+**Remaining: Match9 [9]** (`OPTIONAL MATCH p = (a)-[r*]->(x) RETURN r,x,p`) —
+an OPTIONAL **variable-length named path** that must return null when unmatched.
+Layers path-through-WITH/projection on top of P3's OPTIONAL-varlen-null and the
+varlen elem_ids hydration; deferred as a distinct follow-up.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
@@ -4,14 +4,14 @@ level: task
 title: "P4: Named path through WITH / OPTIONAL varlen null"
 short_code: "GQLITE-T-0337"
 created_at: 2026-05-27T02:49:38.770497+00:00
-updated_at: 2026-05-27T20:32:50.670781+00:00
+updated_at: 2026-05-28T01:42:08.412157+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -37,13 +37,11 @@ Target scenarios: **With1 [4], Match9 [9]**.
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-- [ ] With1 [4] and Match9 [9] move to pass.
-- [ ] `MATCH p=... WITH p RETURN p` projects the path through the WITH boundary.
-- [ ] OPTIONAL varlen named path with no match returns null, not `[]`.
-- [ ] Zero TCK regressions; unit 944/944; functional clean.
-- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+- [x] With1 [4] and Match9 [9] move to pass.
+- [x] `MATCH p=... WITH p RETURN p` projects the path through the WITH boundary.
+- [x] OPTIONAL varlen named path with no match returns null, not `[]`.
+- [x] Zero TCK regressions; unit 944/944; functional clean.
+- [x] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
 
 ## Implementation Notes
 
@@ -120,7 +118,18 @@ Scoped tightly: non-path WITH items and non-projected RETURN paths fall through
 unchanged. **Verified: +1 (With1 [4]), zero regressions** (rigorous pass-set
 diff vs HEAD~1), unit 944/944, functional clean. Commit ce… (P4).
 
-**Remaining: Match9 [9]** (`OPTIONAL MATCH p = (a)-[r*]->(x) RETURN r,x,p`) —
-an OPTIONAL **variable-length named path** that must return null when unmatched.
-Layers path-through-WITH/projection on top of P3's OPTIONAL-varlen-null and the
-varlen elem_ids hydration; deferred as a distinct follow-up.
+### 2026-05-27 — Match9 [9] FIXED (+1); P4 COMPLETE
+
+`OPTIONAL MATCH p = (a)-[r*]->(x) RETURN r, x, p` returned `r=[]` on the
+no-match row (x=C) instead of `r=null`. The varlen edge-list projection
+(`SELECT json_group_array(…) FROM json_each('[' || alias.elem_ids || ']')`)
+yields `'[]'` when `elem_ids` is NULL (OPTIONAL miss): `json_each(NULL)` → 0
+rows → `json_group_array()` returns an empty array, not NULL. Wrapped the
+projection in `CASE WHEN alias.elem_ids IS NULL THEN NULL ELSE (…) END`
+(commit 9ee353c). The path `p` and node `x` columns were already correct.
+
+**Verified: +1 (Match9 [9]), zero regressions** (full pass-set diff), unit
+944/944, functional clean.
+
+**P4 (T-0337) COMPLETE: +2** (With1 [4] path-through-WITH; Match9 [9] OPTIONAL
+varlen named-path null).

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0337.md
@@ -4,14 +4,14 @@ level: task
 title: "P4: Named path through WITH / OPTIONAL varlen null"
 short_code: "GQLITE-T-0337"
 created_at: 2026-05-27T02:49:38.770497+00:00
-updated_at: 2026-05-27T02:49:38.770497+00:00
+updated_at: 2026-05-27T20:32:50.670781+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -34,6 +34,8 @@ Two related path-variable bugs:
    doesn't match returns `[]` instead of SQL `null`.
 
 Target scenarios: **With1 [4], Match9 [9]**.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 
@@ -67,4 +69,31 @@ broad. Diff the full WITH-family TCK features specifically.
 
 ## Status Updates
 
-*To be added during implementation*
+### 2026-05-27 — Root-caused With1 [4]; fix is a path-projection extraction refactor
+
+`MATCH p = (a) WITH p RETURN p` errors `no such column: p`. Dumped SQL:
+- Without WITH: `MATCH p = (a) RETURN p` → `SELECT '[' || alias.id || ']' …`
+  (the path is hydrated by transform_return's path-projection block).
+- With WITH: `WITH _with_0 AS (SELECT p FROM nodes AS alias) SELECT _with_0.p
+  FROM _with_0` — the WITH projection emits a **bare `p`** column. In
+  `transform_with.c` (item loop ~389), a path variable has no table alias
+  (`transform_var_get_alias` returns NULL) and no `AST_NODE_PROPERTY`/identifier
+  branch handles it, so it falls to `dbuf_append(&col_buf, id->name)` → literal
+  `p` → no such column.
+
+**Root cause:** the path-hydration projection (`'[' || …elem_ids/path_ids… ']'`,
+or the comprehension `json_object('nodes',…,'rels',…)`) lives **only** in
+`transform_return.c` (lines ~836-965, gated on `transform_var_is_path`). WITH
+has no equivalent, so path variables can't cross a WITH boundary.
+
+**Fix (deferred — refactor):** extract that ~150-line path-projection block
+into a shared helper (e.g. `emit_path_value(ctx, path_var)`) and call it from
+both `transform_return.c` and the `transform_with.c` item loop (projecting
+`<path_sql> AS p` and registering `p` as a projected column so the outer
+RETURN reads `_with_0.p`). Mechanical but touches WITH projection, which is
+broad — the initiative flags WITH-threading as high regression risk, so it
+needs the full WITH-family TCK diff. Match9 [9] (OPTIONAL varlen named path →
+null) is a further case layered on the same path-through-WITH plumbing plus
+P3's OPTIONAL-null handling.
+
+Left failing; analysis captured for the focused follow-up.

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0338.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0338.md
@@ -1,0 +1,70 @@
+---
+id: p5-match-merge-re-match-inline
+level: task
+title: "P5: MATCH+MERGE re-match inline property preservation"
+short_code: "GQLITE-T-0338"
+created_at: 2026-05-27T02:49:41.681293+00:00
+updated_at: 2026-05-27T02:49:41.681293+00:00
+parent: GQLITE-I-0047
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: GQLITE-I-0047
+---
+
+# P5: MATCH+MERGE re-match inline property preservation
+
+## Parent Initiative
+
+[[GQLITE-I-0047]]
+
+## Objective
+
+In MATCH+MERGE, `handle_match_merge`'s RETURN re-matches a synthetic
+(MATCH ∪ MERGE) combined pattern. Inline node properties like `{id:2}` are
+**dropped** from the generated re-match SQL, so an undirected MERGE matches all
+node pairs instead of the intended one → result rows are doubled. (The
+undirected edge-find itself was already fixed in I-0044; this is specifically
+the re-match property drop.)
+
+Target scenarios: **Merge5 [12]/[13]**.
+
+## Acceptance Criteria
+
+- [ ] Merge5 [12]/[13] move to pass.
+- [ ] MATCH+MERGE re-match carries inline node properties into the generated SQL.
+- [ ] Undirected MERGE returns the correct (non-doubled) row count.
+- [ ] Zero TCK regressions; unit 944/944; functional clean.
+- [ ] TCK delta logged here and rolled up to [[GQLITE-I-0047]].
+
+## Implementation Notes
+
+### Technical Approach
+
+Locate where `handle_match_merge` builds the synthetic re-match pattern and
+ensure inline `{...}` property maps from the MERGE pattern are propagated into
+the re-match's node-pattern property filters. Preferred fix is preserving the
+properties on the re-match pattern; the documented fallback (per the
+initiative's Alternatives) is to project from the MERGE var_map directly,
+but the var_map currently binds only one row — revisit only if the
+property-propagation fix proves harder than expected.
+
+### Dependencies
+
+Independent of P1–P4. Smallest, most isolated cluster — good standalone PR
+candidate.
+
+### Risk Considerations
+
+Re-match SQL is shared by directed MERGE too; confirm directed MERGE+RETURN
+scenarios don't regress.
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0338.md
+++ b/.metis/initiatives/GQLITE-I-0047/tasks/GQLITE-T-0338.md
@@ -4,14 +4,14 @@ level: task
 title: "P5: MATCH+MERGE re-match inline property preservation"
 short_code: "GQLITE-T-0338"
 created_at: 2026-05-27T02:49:41.681293+00:00
-updated_at: 2026-05-27T02:49:41.681293+00:00
+updated_at: 2026-05-27T19:19:46.747917+00:00
 parent: GQLITE-I-0047
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -34,6 +34,8 @@ undirected edge-find itself was already fixed in I-0044; this is specifically
 the re-match property drop.)
 
 Target scenarios: **Merge5 [12]/[13]**.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 
@@ -67,4 +69,39 @@ scenarios don't regress.
 
 ## Status Updates
 
-*To be added during implementation*
+### 2026-05-27 — Root-caused precisely; clean fix blocked by SET's dependency on the same AST mutation
+
+Traced Merge5 [12]/[13] (`MATCH (a {id:2}),(b {id:1}) MERGE (a)-[r:KNOWS]-(b)
+RETURN r` → 2 rows, expected 1) end-to-end:
+
+- MERGE does **not** create a duplicate edge (rc=0, edge count stays 1) — so
+  it's not a MERGE write bug.
+- `handle_match_merge` builds a combined synth pattern (MATCH ∪ MERGE) and
+  re-matches via `execute_match_return_query`. Dumping that synth's SQL shows
+  the node **property filters `{id:2}`/`{id:1}` are gone**:
+  `FROM nodes AS a JOIN nodes AS b ON 1=1 CROSS JOIN edges WHERE ((src=a AND
+  tgt=b) OR (src=b AND tgt=a)) AND type='KNOWS'`. With a,b unconstrained, the
+  undirected OR matches the single edge in *both* (a,b) assignments → 2 rows.
+- **Root cause: AST mutation.** `generate_node_match` does
+  `first_pair->key = NULL` (transform_match.c:1438/1536/1900) to mark the
+  first inline property "handled" (it seeds the FROM table for selectivity).
+  The MERGE execution transforms the MATCH first (nulling the keys), then the
+  RETURN synth re-transforms the **same** AST nodes — now with null keys → the
+  `{id:…}` filters vanish. The standalone equivalent (`MATCH … , (a)-[r]-(b)`)
+  works because it's transformed once.
+
+**Attempted fix (reverted):** stop nulling the key (the constraint pass then
+re-emits it as a redundant-but-correct EXISTS). This fixed Merge5 [12]/[13]
+(+2) but **regressed Set4 [2]/[3]/[4] and Set5 [4]** (−4, net −2): the SET path
+(`MATCH (n:X {name:'A'}) SET n = {…}`) depends on the mutation for its own
+transform reuse. Reverted.
+
+**Conclusion:** the right fix is "don't mutate shared AST" — but it must be
+done **together** with making the SET path independent of the mutation (e.g.
+pass the FROM-consumed property index through the transform context instead of
+nulling the AST, and update both the property-constraint pass and SET). That's
+a coordinated transform refactor, deferred. Alternatively, deep-copy the
+patterns in `handle_match_merge` before the synth re-match (localized, avoids
+the SET entanglement) — a viable narrower follow-up.
+
+Merge5 [12]/[13] left failing; analysis captured for the follow-up.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -165,3 +165,28 @@ Cross-cutting read-back semantics (orderability total order over
 node/rel/list/map/scalar, list `=`/`IN`, `min`/`max`) also landed; their
 remaining deep tail is tracked in initiatives [[GQLITE-I-0046]] /
 [[GQLITE-I-0047]] / [[GQLITE-I-0048]].
+
+## Coverage update (2026-05-27) — I-0047 P1: undirected variable-length paths
+
+GQLITE-T-0334 (initiative [[GQLITE-I-0047]]). Verified through the openCypher
+TCK harness (`angreal test tck`, full pass-set diff, zero regressions; unit
+944/944; functional clean):
+
+- **`MATCH (a)-[*]-(b)` (undirected variable-length)** now traverses *both*
+  edge orientations. `generate_varlen_cte` previously emitted only the
+  `source_id → target_id` direction, so an undirected varlen MATCH undercounted
+  (3 directed rows where openCypher matches 6). The recursive CTE base case now
+  UNIONs both orientations and the recursive step advances to the edge's *other*
+  endpoint (`source_id = end OR target_id = end`); the outer endpoint binding
+  stays directional. Fixes Match9 [1]/[3].
+- **`MATCH … DETACH DELETE a,b RETURN count(*)`** — `count()` is now computed
+  from the live pre-delete MATCH (`handle_match_delete` pre-capture) instead of
+  the accumulated delete count. The old delete-count path only *coincidentally*
+  matched the expected aggregate for undirected-varlen shapes the MATCH
+  undercounted; with the MATCH now correct it would have over-counted. Fixes
+  Delete4 [1] (single-hop undirected, +1 bonus) and keeps Delete4 [2] correct.
+
+Net TCK delta: +3 (Match9 [1], Match9 [3], Delete4 [1]), zero regressions.
+Remaining I-0047 P1 targets (Pattern1 [10]/[17]/[18] undirected varlen inside
+WHERE `EXISTS`-pattern predicates; Match6 [14]/[17] multi-segment / zero-length
+named paths) are distinct generators tracked under GQLITE-T-0334 / P2 / P4.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -198,3 +198,21 @@ Net TCK delta: +6 (Match9 [1]/[3], Delete4 [1], Pattern1 [10]/[17]/[18]), zero
 regressions. Remaining I-0047 targets Match6 [14] (multi-segment fixed+varlen
 named path) and Match6 [17] (zero-length named path) are distinct generators
 tracked under P2 (GQLITE-T-0335) / P4 (GQLITE-T-0337).
+
+## Coverage update (2026-05-27) — I-0047 P2: varlen relationship-property predicate
+
+GQLITE-T-0335. Verified via the TCK harness (full pass-set diff, zero
+regressions; unit 944/944; functional clean):
+
+- **`MATCH (a)-[:T* {k: v}]->(b)` (inline relationship property predicate on a
+  variable-length rel)** — `generate_varlen_cte`'s per-edge filter now folds in
+  inline rel property predicates (an `edge_props_*` EXISTS per `{k: v}` pair)
+  alongside the type constraint, applied to every edge in the base and
+  recursive steps. Previously the property map was ignored, so the path matched
+  regardless of edge properties. Fixes Match4 [5] (+1).
+
+Investigation note: the Match5 [25]/[26]/[28]/[29] "multi-segment chain"
+failures turned out **not** to be a path-matching bug — multi-segment
+fixed+varlen chains already match correctly. They fail because their setup
+(`MATCH (d:D) CREATE …`) only processes the first matched row — a write-path
+multiplicity bug filed as GQLITE-T-0339, out of this initiative's scope.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -186,7 +186,15 @@ TCK harness (`angreal test tck`, full pass-set diff, zero regressions; unit
   undercounted; with the MATCH now correct it would have over-counted. Fixes
   Delete4 [1] (single-hop undirected, +1 bonus) and keeps Delete4 [2] correct.
 
-Net TCK delta: +3 (Match9 [1], Match9 [3], Delete4 [1]), zero regressions.
-Remaining I-0047 P1 targets (Pattern1 [10]/[17]/[18] undirected varlen inside
-WHERE `EXISTS`-pattern predicates; Match6 [14]/[17] multi-segment / zero-length
-named paths) are distinct generators tracked under GQLITE-T-0334 / P2 / P4.
+- **`MATCH (n) WHERE (n)-[:R*..]-(m)` (varlen inside a WHERE existential
+  pattern predicate)** — the `AST_NODE_PATH` EXISTS emitter
+  (`transform_expr_predicate.c`) previously treated every rel as a single fixed
+  hop, ignoring `rel->varlen`. New `emit_exists_varlen_path` emits a correlated
+  recursive-CTE reachability check (same bidirectional traversal as the MATCH
+  CTE; endpoint labels honored; inline endpoint properties fall back). Fixes
+  Pattern1 [10]/[17]/[18].
+
+Net TCK delta: +6 (Match9 [1]/[3], Delete4 [1], Pattern1 [10]/[17]/[18]), zero
+regressions. Remaining I-0047 targets Match6 [14] (multi-segment fixed+varlen
+named path) and Match6 [17] (zero-length named path) are distinct generators
+tracked under P2 (GQLITE-T-0335) / P4 (GQLITE-T-0337).

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -216,3 +216,19 @@ failures turned out **not** to be a path-matching bug — multi-segment
 fixed+varlen chains already match correctly. They fail because their setup
 (`MATCH (d:D) CREATE …`) only processes the first matched row — a write-path
 multiplicity bug filed as GQLITE-T-0339, out of this initiative's scope.
+
+## Coverage update (2026-05-27) — I-0047 P3: OPTIONAL MATCH row preservation
+
+GQLITE-T-0336 (partial). Verified via the TCK harness (full pass-set diff,
+zero regressions; unit 944/944; functional clean):
+
+- **OPTIONAL node label constraints no longer drop the preserved anchor row.**
+  An OPTIONAL node's label was emitted as an INNER `node_labels` join (for
+  varlen-deferred targets and for every non-first optional node), which inner-
+  joins away the NULL-seed row when the optional doesn't match. Labels now fold
+  into the node's LEFT JOIN ON as a correlated EXISTS. Fixes Match7 [15]
+  (OPTIONAL varlen + nulls) and Aggregation5 [2] (OPTIONAL MATCH + collect).
+
+Remaining OPTIONAL work (multi-rel combined-EXISTS join ordering, bound-rel
+reverse optional, chained-OPTIONAL null-var binding, varlen optional counts) is
+tracked under GQLITE-T-0336.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -229,6 +229,16 @@ zero regressions; unit 944/944; functional clean):
   into the node's LEFT JOIN ON as a correlated EXISTS. Fixes Match7 [15]
   (OPTIONAL varlen + nulls) and Aggregation5 [2] (OPTIONAL MATCH + collect).
 
-Remaining OPTIONAL work (multi-rel combined-EXISTS join ordering, bound-rel
-reverse optional, chained-OPTIONAL null-var binding, varlen optional counts) is
-tracked under GQLITE-T-0336.
+- **Variable-length paths now enforce relationship-uniqueness, not
+  node-uniqueness.** `(s)-[:REL]->(b)-[:LOOP]->(b)` is a valid varlen path (two
+  distinct edges) even though it revisits `b`; the CTE previously blocked node
+  revisits. Fixes Match7 [12].
+- **WITH-projected NULL node/edge variables render as SQL NULL in RETURN.** A
+  node/edge bound via OPTIONAL and carried across WITH, when NULL, was projected
+  as a bogus `{id:null,…}` object; the post-WITH projection now guards with
+  `CASE WHEN id IS NULL THEN NULL`. Fixes Match7 [21], [27].
+
+P3 net: +5 (Match7 [12]/[15]/[21]/[27], Aggregation5 [2]). Remaining OPTIONAL
+work (multi-rel combined-EXISTS join ordering → derived-table rewrite;
+bound-rel reverse optional → deferred-constraint plumbing) tracked under
+GQLITE-T-0336.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -254,5 +254,11 @@ HEAD, zero regressions; unit 944/944; functional clean):
   WITH now emits the path-hydration SQL `AS p`, preserves the path metadata
   across the scope reset, and re-registers `p` as a path var on the CTE column;
   RETURN emits that column directly and the executor hydrates it. Fixes
-  With1 [4]. Match9 [9] (OPTIONAL varlen named path → null) remains under
-  GQLITE-T-0337.
+  With1 [4].
+- **OPTIONAL variable-length relationship list returns NULL (not `[]`) on a
+  no-match.** The varlen edge-list projection used `json_group_array` over
+  `json_each('[' || elem_ids || ']')`, which yields `'[]'` when `elem_ids` is
+  NULL (OPTIONAL miss). Wrapped it in `CASE WHEN elem_ids IS NULL THEN NULL`.
+  Fixes Match9 [9].
+
+P4 (GQLITE-T-0337) complete: +2 (With1 [4], Match9 [9]).

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -242,3 +242,17 @@ P3 net: +5 (Match7 [12]/[15]/[21]/[27], Aggregation5 [2]). Remaining OPTIONAL
 work (multi-rel combined-EXISTS join ordering → derived-table rewrite;
 bound-rel reverse optional → deferred-constraint plumbing) tracked under
 GQLITE-T-0336.
+
+## Coverage update (2026-05-27) — I-0047 P4: forward a path variable through WITH
+
+GQLITE-T-0337. Verified via the TCK harness (rigorous pass-set diff vs prior
+HEAD, zero regressions; unit 944/944; functional clean):
+
+- **`MATCH p = (…) WITH p … RETURN p` now carries the path across the WITH
+  boundary.** WITH's item loop bypassed `transform_expression` (which hydrates
+  path vars), so a forwarded path emitted a bare `p` column → "no such column".
+  WITH now emits the path-hydration SQL `AS p`, preserves the path metadata
+  across the scope reset, and re-registers `p` as a path var on the CTE column;
+  RETURN emits that column directly and the executor hydrates it. Fixes
+  With1 [4]. Match9 [9] (OPTIONAL varlen named path → null) remains under
+  GQLITE-T-0337.

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -807,16 +807,21 @@ static int handle_match_delete(cypher_executor *executor, cypher_query *query,
      * (e.g. `type(r)` or `r.prop`). After DELETE, the entity is
      * gone and the lookup yields NULL.
      *
-     * For COUNT(*) and literal RETURNs, the existing
-     * synthesize_delete_return path is preserved — it uses the
-     * accumulated delete counts which (by historical coincidence)
-     * sometimes match expected aggregate counts for shapes our
-     * MATCH undercounts (e.g. undirected varlen). Pre-MATCHing
-     * those would regress them.
+     * I-0047 P1: `count(*)` is pre-captured too. It must reflect the
+     * number of MATCHED rows, which `execute_match_return_query`
+     * computes directly. The legacy `synthesize_delete_return` path
+     * derived `count` from the accumulated *delete* count
+     * (nodes_deleted + rels_deleted, with no endpoint dedup), which
+     * only coincidentally matched the expected aggregate for shapes
+     * our MATCH undercounted (e.g. undirected varlen, where 3 directed
+     * rows × 2 deleted endpoints == the 6 rows real Cypher matches).
+     * Now that undirected varlen traverses both orientations (the
+     * MATCH row count is correct), that coincidence would over-count
+     * (6 rows × 2 == 12) — so count() goes through the live MATCH.
      *
-     * Decision: only pre-capture RETURN when synthesize wouldn't
-     * fire — i.e. when items include property/function projections
-     * that need live entity data. */
+     * Literal RETURNs still use synthesize_delete_return (its
+     * total_deleted row multiplier is left as-is); only count() and
+     * entity-data projections pre-capture. */
     cypher_return *ret_clause = (flags & CLAUSE_RETURN) ? find_return_clause(query) : NULL;
     bool needs_pre_capture = false;
     if (ret_clause && ret_clause->items) {
@@ -824,17 +829,11 @@ static int handle_match_delete(cypher_executor *executor, cypher_query *query,
             cypher_return_item *it = (cypher_return_item *)ret_clause->items->items[i];
             if (!it || !it->expr) continue;
             ast_node_type t = it->expr->type;
-            /* synthesize_delete_return handles LITERAL and the
-             * count() aggregate. Everything else (property
-             * access, type()/labels()/id() function calls,
-             * variable bare references, etc.) needs the live
-             * entity data. */
+            /* synthesize_delete_return handles bare LITERAL rows.
+             * Everything else (count() aggregate, property access,
+             * type()/labels()/id() function calls, variable bare
+             * references, etc.) needs the live pre-delete MATCH. */
             if (t == AST_NODE_LITERAL) continue;
-            if (t == AST_NODE_FUNCTION_CALL) {
-                cypher_function_call *fc = (cypher_function_call *)it->expr;
-                if (fc->function_name &&
-                    strcasecmp(fc->function_name, "count") == 0) continue;
-            }
             needs_pre_capture = true;
             break;
         }

--- a/src/backend/transform/cypher_transform.c
+++ b/src/backend/transform/cypher_transform.c
@@ -1202,6 +1202,34 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
         src_col = "target_id";
         tgt_col = "source_id";
     }
+    /* Undirected (`-[*]-` / `--`): traverse both edge orientations.
+     * Each undirected walk is emitted once per direction (matching
+     * openCypher's both-orientation semantics, e.g. Match9 [1]/[3]),
+     * while the outer endpoint binding stays directional
+     * (`start_id = a.id AND end_id = b.id`). */
+    bool undirected = (!rel->left_arrow && !rel->right_arrow);
+
+    /* Build the relationship-type predicate once as a bare boolean
+     * expression (no WHERE/AND prefix), reused across base orientations
+     * and the recursive step. Empty when no type constraint. */
+    dynamic_buffer tpred;
+    dbuf_init(&tpred);
+    if (rel->type) {
+        char *esc = escape_sql_string(rel->type);
+        dbuf_appendf(&tpred, "e.type = '%s'", esc ? esc : rel->type);
+        free(esc);
+    } else if (rel->types && rel->types->count > 0) {
+        dbuf_append(&tpred, "(");
+        for (int t = 0; t < rel->types->count; t++) {
+            if (t > 0) dbuf_append(&tpred, " OR ");
+            cypher_literal *type_lit = (cypher_literal*)rel->types->items[t];
+            char *esc = escape_sql_string(type_lit->value.string);
+            dbuf_appendf(&tpred, "e.type = '%s'", esc ? esc : type_lit->value.string);
+            free(esc);
+        }
+        dbuf_append(&tpred, ")");
+    }
+    bool have_tpred = (dbuf_len(&tpred) > 0);
 
     /* Zero-hop base case (only when explicitly requested via *0..N):
      * each node maps to itself with depth=0. */
@@ -1225,66 +1253,73 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
         src_col, tgt_col,
         src_col, tgt_col,
         src_col, tgt_col);
+    if (have_tpred) dbuf_appendf(&cte_query, " WHERE %s", dbuf_get(&tpred));
 
-    /* Add type constraint if specified */
-    if (rel->type) {
-        { char *esc = escape_sql_string(rel->type);
-          dbuf_appendf(&cte_query, " WHERE e.type = '%s'", esc ? esc : rel->type);
-          free(esc); }
-    } else if (rel->types && rel->types->count > 0) {
-        dbuf_append(&cte_query, " WHERE (");
-        for (int t = 0; t < rel->types->count; t++) {
-            if (t > 0) {
-                dbuf_append(&cte_query, " OR ");
-            }
-            cypher_literal *type_lit = (cypher_literal*)rel->types->items[t];
-            { char *esc = escape_sql_string(type_lit->value.string);
-              dbuf_appendf(&cte_query, "e.type = '%s'", esc ? esc : type_lit->value.string);
-              free(esc); }
-        }
-        dbuf_append(&cte_query, ")");
+    /* Undirected: emit the reverse-orientation base case too, so each
+     * edge seeds a walk in both directions. */
+    if (undirected) {
+        dbuf_appendf(&cte_query,
+            " UNION ALL "
+            "SELECT e.%s, e.%s, 1, "
+            "CAST(e.%s || ',' || e.%s AS TEXT), "
+            "','|| e.%s || ',' || e.%s || ',', "
+            "e.%s || ',' || e.id || ',' || e.%s "
+            "FROM edges e",
+            tgt_col, src_col,
+            tgt_col, src_col,
+            tgt_col, src_col,
+            tgt_col, src_col);
+        if (have_tpred) dbuf_appendf(&cte_query, " WHERE %s", dbuf_get(&tpred));
     }
 
     /* Recursive case — only recurse from depth >= 1 rows. The depth=0
      * base case is for self-bind (zero-hop); recursing from it would
      * duplicate edges already emitted by the depth=1 base case. */
     dbuf_append(&cte_query, " UNION ALL ");
-    dbuf_appendf(&cte_query,
-        "SELECT cte.start_id, e.%s, cte.depth + 1, "
-        "cte.path_ids || ',' || e.%s, "
-        "cte.visited || e.%s || ',', "
-        "cte.elem_ids || ',' || e.id || ',' || e.%s "
-        "FROM %s cte "
-        "JOIN edges e ON e.%s = cte.end_id "
-        "WHERE cte.depth >= 1 AND cte.depth < %d",
-        tgt_col, tgt_col, tgt_col, tgt_col,
-        cte_name,
-        src_col,
-        max_hops);
-
-    /* Add cycle detection */
-    dbuf_appendf(&cte_query,
-        " AND cte.visited NOT LIKE '%%,' || CAST(e.%s AS TEXT) || ',%%'",
-        tgt_col);
+    if (undirected) {
+        /* Undirected step: join any edge incident to the current end
+         * node and advance to its OTHER endpoint. The "other endpoint"
+         * is `target_id` when we entered via `source_id`, else
+         * `source_id`. Node-based cycle prevention (matches the
+         * directed path's behavior). */
+        const char *other =
+            "(CASE WHEN e.source_id = cte.end_id THEN e.target_id ELSE e.source_id END)";
+        dbuf_appendf(&cte_query,
+            "SELECT cte.start_id, %s, cte.depth + 1, "
+            "cte.path_ids || ',' || %s, "
+            "cte.visited || %s || ',', "
+            "cte.elem_ids || ',' || e.id || ',' || %s "
+            "FROM %s cte "
+            "JOIN edges e ON (e.source_id = cte.end_id OR e.target_id = cte.end_id) "
+            "WHERE cte.depth >= 1 AND cte.depth < %d",
+            other, other, other, other,
+            cte_name,
+            max_hops);
+        dbuf_appendf(&cte_query,
+            " AND cte.visited NOT LIKE '%%,' || CAST(%s AS TEXT) || ',%%'",
+            other);
+    } else {
+        dbuf_appendf(&cte_query,
+            "SELECT cte.start_id, e.%s, cte.depth + 1, "
+            "cte.path_ids || ',' || e.%s, "
+            "cte.visited || e.%s || ',', "
+            "cte.elem_ids || ',' || e.id || ',' || e.%s "
+            "FROM %s cte "
+            "JOIN edges e ON e.%s = cte.end_id "
+            "WHERE cte.depth >= 1 AND cte.depth < %d",
+            tgt_col, tgt_col, tgt_col, tgt_col,
+            cte_name,
+            src_col,
+            max_hops);
+        /* Add cycle detection */
+        dbuf_appendf(&cte_query,
+            " AND cte.visited NOT LIKE '%%,' || CAST(e.%s AS TEXT) || ',%%'",
+            tgt_col);
+    }
 
     /* Add type constraint to recursive case */
-    if (rel->type) {
-        { char *esc = escape_sql_string(rel->type);
-          dbuf_appendf(&cte_query, " AND e.type = '%s'", esc ? esc : rel->type);
-          free(esc); }
-    } else if (rel->types && rel->types->count > 0) {
-        dbuf_append(&cte_query, " AND (");
-        for (int t = 0; t < rel->types->count; t++) {
-            if (t > 0) {
-                dbuf_append(&cte_query, " OR ");
-            }
-            cypher_literal *type_lit = (cypher_literal*)rel->types->items[t];
-            { char *esc = escape_sql_string(type_lit->value.string);
-              dbuf_appendf(&cte_query, "e.type = '%s'", esc ? esc : type_lit->value.string);
-              free(esc); }
-        }
-        dbuf_append(&cte_query, ")");
-    }
+    if (have_tpred) dbuf_appendf(&cte_query, " AND %s", dbuf_get(&tpred));
+    dbuf_free(&tpred);
 
     /* Build CTE name with column definitions */
     char cte_full_name[256];

--- a/src/backend/transform/cypher_transform.c
+++ b/src/backend/transform/cypher_transform.c
@@ -1268,11 +1268,19 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
     }
     bool have_tpred = (dbuf_len(&tpred) > 0);
 
+    /* The `visited` column tracks traversed EDGE ids (not node ids):
+     * openCypher variable-length semantics require RELATIONSHIP uniqueness
+     * (each edge used at most once) while nodes MAY repeat — e.g.
+     * `(s)-[:REL]->(b)-[:LOOP]->(b)` is a valid 2-hop path (two distinct
+     * edges) even though it revisits b. Node-based cycle prevention wrongly
+     * dropped such paths (Match7 [12]). Edge ids are finite so traversal
+     * still terminates. */
+
     /* Zero-hop base case (only when explicitly requested via *0..N):
-     * each node maps to itself with depth=0. */
+     * each node maps to itself with depth=0 and no traversed edges. */
     if (min_hops == 0) {
         dbuf_appendf(&cte_query,
-            "SELECT n.id, n.id, 0, CAST(n.id AS TEXT), ',' || n.id || ',', "
+            "SELECT n.id, n.id, 0, CAST(n.id AS TEXT), ',', "
             "CAST(n.id AS TEXT) "
             "FROM nodes n UNION ALL ");
     }
@@ -1283,10 +1291,9 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
     dbuf_appendf(&cte_query,
         "SELECT e.%s, e.%s, 1, "
         "CAST(e.%s || ',' || e.%s AS TEXT), "
-        "','|| e.%s || ',' || e.%s || ',', "
+        "',' || e.id || ',', "
         "e.%s || ',' || e.id || ',' || e.%s "
         "FROM edges e",
-        src_col, tgt_col,
         src_col, tgt_col,
         src_col, tgt_col,
         src_col, tgt_col);
@@ -1299,10 +1306,9 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
             " UNION ALL "
             "SELECT e.%s, e.%s, 1, "
             "CAST(e.%s || ',' || e.%s AS TEXT), "
-            "','|| e.%s || ',' || e.%s || ',', "
+            "',' || e.id || ',', "
             "e.%s || ',' || e.id || ',' || e.%s "
             "FROM edges e",
-            tgt_col, src_col,
             tgt_col, src_col,
             tgt_col, src_col,
             tgt_col, src_col);
@@ -1324,34 +1330,33 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
         dbuf_appendf(&cte_query,
             "SELECT cte.start_id, %s, cte.depth + 1, "
             "cte.path_ids || ',' || %s, "
-            "cte.visited || %s || ',', "
+            "cte.visited || e.id || ',', "
             "cte.elem_ids || ',' || e.id || ',' || %s "
             "FROM %s cte "
             "JOIN edges e ON (e.source_id = cte.end_id OR e.target_id = cte.end_id) "
             "WHERE cte.depth >= 1 AND cte.depth < %d",
-            other, other, other, other,
+            other, other, other,
             cte_name,
             max_hops);
-        dbuf_appendf(&cte_query,
-            " AND cte.visited NOT LIKE '%%,' || CAST(%s AS TEXT) || ',%%'",
-            other);
+        /* Relationship-uniqueness: don't reuse an edge already on the path. */
+        dbuf_append(&cte_query,
+            " AND cte.visited NOT LIKE '%,' || CAST(e.id AS TEXT) || ',%'");
     } else {
         dbuf_appendf(&cte_query,
             "SELECT cte.start_id, e.%s, cte.depth + 1, "
             "cte.path_ids || ',' || e.%s, "
-            "cte.visited || e.%s || ',', "
+            "cte.visited || e.id || ',', "
             "cte.elem_ids || ',' || e.id || ',' || e.%s "
             "FROM %s cte "
             "JOIN edges e ON e.%s = cte.end_id "
             "WHERE cte.depth >= 1 AND cte.depth < %d",
-            tgt_col, tgt_col, tgt_col, tgt_col,
+            tgt_col, tgt_col, tgt_col,
             cte_name,
             src_col,
             max_hops);
-        /* Add cycle detection */
-        dbuf_appendf(&cte_query,
-            " AND cte.visited NOT LIKE '%%,' || CAST(e.%s AS TEXT) || ',%%'",
-            tgt_col);
+        /* Relationship-uniqueness: don't reuse an edge already on the path. */
+        dbuf_append(&cte_query,
+            " AND cte.visited NOT LIKE '%,' || CAST(e.id AS TEXT) || ',%'");
     }
 
     /* Add type constraint to recursive case */

--- a/src/backend/transform/cypher_transform.c
+++ b/src/backend/transform/cypher_transform.c
@@ -119,6 +119,7 @@ void cypher_transform_free_context(cypher_transform_context *ctx)
     free(ctx->sql_buffer);
     free(ctx->error_message);
     free(ctx->pending_prop_joins);
+    free(ctx->pending_optional_on);
 
     /* T-0320: free defer-pair tracking. */
     for (int i = 0; i < ctx->optional_defer_pairs_count; i++) {

--- a/src/backend/transform/cypher_transform.c
+++ b/src/backend/transform/cypher_transform.c
@@ -1209,9 +1209,11 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
      * (`start_id = a.id AND end_id = b.id`). */
     bool undirected = (!rel->left_arrow && !rel->right_arrow);
 
-    /* Build the relationship-type predicate once as a bare boolean
-     * expression (no WHERE/AND prefix), reused across base orientations
-     * and the recursive step. Empty when no type constraint. */
+    /* Build the per-edge predicate once as a bare boolean expression (no
+     * WHERE/AND prefix), reused across base orientations and the recursive
+     * step. Folds together the relationship type constraint AND any inline
+     * relationship property predicates (`[:T* {k: v}]`), all referencing the
+     * base/recursive edge alias `e`. Empty when neither is present. */
     dynamic_buffer tpred;
     dbuf_init(&tpred);
     if (rel->type) {
@@ -1228,6 +1230,41 @@ int generate_varlen_cte(cypher_transform_context *ctx, cypher_rel_pattern *rel,
             free(esc);
         }
         dbuf_append(&tpred, ")");
+    }
+    /* Inline rel property predicates: every edge along the varlen path must
+     * carry the given properties (Match4 [5] `[:WORKED_WITH* {year:1988}]`). */
+    if (rel->properties && rel->properties->type == AST_NODE_MAP) {
+        cypher_map *m = (cypher_map*)rel->properties;
+        if (m->pairs) {
+            for (int pi = 0; pi < m->pairs->count; pi++) {
+                cypher_map_pair *pair = (cypher_map_pair*)m->pairs->items[pi];
+                if (!pair->key || !pair->value || pair->value->type != AST_NODE_LITERAL) continue;
+                cypher_literal *lit = (cypher_literal*)pair->value;
+                const char *tbl = NULL;
+                char val_buf[256] = "";
+                switch (lit->literal_type) {
+                    case LITERAL_STRING: tbl = "edge_props_text";
+                        { char *esc = escape_sql_string(lit->value.string);
+                          snprintf(val_buf, sizeof(val_buf), "'%s'", esc ? esc : lit->value.string);
+                          free(esc); } break;
+                    case LITERAL_INTEGER: tbl = "edge_props_int";
+                        snprintf(val_buf, sizeof(val_buf), "%lld", (long long)lit->value.integer); break;
+                    case LITERAL_DECIMAL: tbl = "edge_props_real";
+                        snprintf(val_buf, sizeof(val_buf), "%.17g", lit->value.decimal); break;
+                    case LITERAL_BOOLEAN: tbl = "edge_props_bool";
+                        snprintf(val_buf, sizeof(val_buf), "%d", lit->value.boolean ? 1 : 0); break;
+                    default: continue;
+                }
+                if (!tbl) continue;
+                if (dbuf_len(&tpred) > 0) dbuf_append(&tpred, " AND ");
+                char *esc_key = escape_sql_string(pair->key);
+                dbuf_appendf(&tpred,
+                    "EXISTS (SELECT 1 FROM %s ep JOIN property_keys pk ON ep.key_id = pk.id "
+                    "WHERE ep.edge_id = e.id AND pk.key = '%s' AND ep.value = %s)",
+                    tbl, esc_key ? esc_key : pair->key, val_buf);
+                free(esc_key);
+            }
+        }
     }
     bool have_tpred = (dbuf_len(&tpred) > 0);
 

--- a/src/backend/transform/transform_expr_predicate.c
+++ b/src/backend/transform/transform_expr_predicate.c
@@ -19,6 +19,155 @@
 #include "parser/cypher_ast.h"
 #include "parser/cypher_debug.h"
 
+/* I-0047 P1: emit the rel-type predicate (bare boolean, no connector)
+ * for a varlen EXISTS-pattern subquery. Returns true if a predicate was
+ * appended. */
+static bool ep_append_type_pred(cypher_transform_context *ctx,
+                                cypher_rel_pattern *rel)
+{
+    if (rel->type) {
+        append_sql(ctx, "e.type = ");
+        append_string_literal(ctx, rel->type);
+        return true;
+    } else if (rel->types && rel->types->count > 0) {
+        append_sql(ctx, "(");
+        for (int t = 0; t < rel->types->count; t++) {
+            if (t > 0) append_sql(ctx, " OR ");
+            append_sql(ctx, "e.type = ");
+            const char *tn = get_label_string(rel->types->items[t]);
+            append_string_literal(ctx, tn ? tn : "");
+        }
+        append_sql(ctx, ")");
+        return true;
+    }
+    return false;
+}
+
+/* I-0047 P1: handle the `(a)-[*..]-(b)` shape inside a WHERE existential
+ * pattern predicate (Pattern1 [10]/[17]/[18]). The legacy emitter below
+ * treats every relationship as a single fixed hop, ignoring `rel->varlen`.
+ * For a path of exactly [node, varlen-rel, node] where the left node is
+ * bound in the outer scope, emit a correlated recursive-CTE reachability
+ * check instead. Returns true if handled (caller appends the closing ")").
+ *
+ * Mirrors generate_varlen_cte's traversal: directed honors arrows,
+ * undirected walks both orientations; node-based cycle prevention. Only
+ * start/end/depth/visited columns are needed for an existence test. */
+static bool emit_exists_varlen_path(cypher_transform_context *ctx, cypher_path *path)
+{
+    if (!path->elements || path->elements->count != 3) return false;
+    ast_node *e0 = path->elements->items[0];
+    ast_node *e1 = path->elements->items[1];
+    ast_node *e2 = path->elements->items[2];
+    if (e0->type != AST_NODE_NODE_PATTERN ||
+        e1->type != AST_NODE_REL_PATTERN ||
+        e2->type != AST_NODE_NODE_PATTERN) return false;
+
+    cypher_rel_pattern *rel = (cypher_rel_pattern*)e1;
+    if (!rel->varlen) return false;
+
+    cypher_node_pattern *lnode = (cypher_node_pattern*)e0;
+    cypher_node_pattern *rnode = (cypher_node_pattern*)e2;
+
+    /* Inline endpoint property maps aren't modelled here — bail so we
+     * don't silently ignore them (preserves pre-I-0047 behavior for that
+     * shape rather than emitting a wrong-but-different result). */
+    if (lnode->properties || rnode->properties) return false;
+
+    /* Left endpoint must be bound in the outer scope to correlate. */
+    const char *lalias = lnode->variable
+        ? transform_var_get_alias(ctx->var_ctx, lnode->variable) : NULL;
+    if (!lalias) return false;
+    const char *ralias = rnode->variable
+        ? transform_var_get_alias(ctx->var_ctx, rnode->variable) : NULL;
+
+    cypher_varlen_range *range = (cypher_varlen_range*)rel->varlen;
+    int min_hops = range->min_hops >= 0 ? range->min_hops : 1;
+    int max_hops = range->max_hops > 0 ? range->max_hops : 100;
+
+    const char *src_col = "source_id", *tgt_col = "target_id";
+    if (rel->left_arrow && !rel->right_arrow) { src_col = "target_id"; tgt_col = "source_id"; }
+    bool undirected = (!rel->left_arrow && !rel->right_arrow);
+
+    char cte[32];
+    snprintf(cte, sizeof(cte), "_epv_%d", ctx->cte_count++);
+
+    append_sql(ctx, "WITH RECURSIVE %s(start_id, end_id, depth, visited) AS (", cte);
+
+    /* Zero-hop base (only for *0..N): each node maps to itself. */
+    if (min_hops == 0) {
+        append_sql(ctx, "SELECT n.id, n.id, 0, ',' || n.id || ',' FROM nodes n UNION ALL ");
+    }
+
+    /* Depth-1 base case. */
+    append_sql(ctx, "SELECT e.%s, e.%s, 1, ',' || e.%s || ',' || e.%s || ',' FROM edges e",
+               src_col, tgt_col, src_col, tgt_col);
+    if (rel->type || (rel->types && rel->types->count > 0)) {
+        append_sql(ctx, " WHERE ");
+        ep_append_type_pred(ctx, rel);
+    }
+    if (undirected) {
+        append_sql(ctx, " UNION ALL SELECT e.%s, e.%s, 1, ',' || e.%s || ',' || e.%s || ',' FROM edges e",
+                   tgt_col, src_col, tgt_col, src_col);
+        if (rel->type || (rel->types && rel->types->count > 0)) {
+            append_sql(ctx, " WHERE ");
+            ep_append_type_pred(ctx, rel);
+        }
+    }
+
+    /* Recursive step. */
+    append_sql(ctx, " UNION ALL ");
+    if (undirected) {
+        const char *other = "(CASE WHEN e.source_id = cte.end_id THEN e.target_id ELSE e.source_id END)";
+        append_sql(ctx,
+            "SELECT cte.start_id, %s, cte.depth + 1, cte.visited || %s || ',' "
+            "FROM %s cte JOIN edges e ON (e.source_id = cte.end_id OR e.target_id = cte.end_id) "
+            "WHERE cte.depth >= 1 AND cte.depth < %d "
+            "AND cte.visited NOT LIKE '%%,' || CAST(%s AS TEXT) || ',%%'",
+            other, other, cte, max_hops, other);
+    } else {
+        append_sql(ctx,
+            "SELECT cte.start_id, e.%s, cte.depth + 1, cte.visited || e.%s || ',' "
+            "FROM %s cte JOIN edges e ON e.%s = cte.end_id "
+            "WHERE cte.depth >= 1 AND cte.depth < %d "
+            "AND cte.visited NOT LIKE '%%,' || CAST(e.%s AS TEXT) || ',%%'",
+            tgt_col, tgt_col, cte, src_col, max_hops, tgt_col);
+    }
+    if (rel->type || (rel->types && rel->types->count > 0)) {
+        append_sql(ctx, " AND ");
+        ep_append_type_pred(ctx, rel);
+    }
+
+    append_sql(ctx, ") SELECT 1 FROM %s WHERE %s.start_id = %s.id", cte, cte, lalias);
+    if (ralias) {
+        append_sql(ctx, " AND %s.end_id = %s.id", cte, ralias);
+    }
+    if (min_hops >= 0) append_sql(ctx, " AND %s.depth >= %d", cte, min_hops);
+    append_sql(ctx, " AND %s.depth <= %d", cte, max_hops);
+
+    /* Honor endpoint label constraints against the CTE's start/end ids
+     * (e.g. `(a)-[:T*]->(b:MissingLabel)`). */
+    if (has_labels(lnode)) {
+        for (int j = 0; j < lnode->labels->count; j++) {
+            const char *lbl = get_label_string(lnode->labels->items[j]);
+            if (!lbl) continue;
+            append_sql(ctx, " AND EXISTS (SELECT 1 FROM node_labels WHERE node_id = %s.start_id AND label = ", cte);
+            append_string_literal(ctx, lbl);
+            append_sql(ctx, ")");
+        }
+    }
+    if (has_labels(rnode)) {
+        for (int j = 0; j < rnode->labels->count; j++) {
+            const char *lbl = get_label_string(rnode->labels->items[j]);
+            if (!lbl) continue;
+            append_sql(ctx, " AND EXISTS (SELECT 1 FROM node_labels WHERE node_id = %s.end_id AND label = ", cte);
+            append_string_literal(ctx, lbl);
+            append_sql(ctx, ")");
+        }
+    }
+    return true;
+}
+
 /* Transform EXISTS expression */
 int transform_exists_expression(cypher_transform_context *ctx, cypher_exists_expr *exists_expr)
 {
@@ -50,6 +199,16 @@ int transform_exists_expression(cypher_transform_context *ctx, cypher_exists_exp
 
                 if (pattern->type == AST_NODE_PATH) {
                     cypher_path *path = (cypher_path*)pattern;
+
+                    /* I-0047 P1: variable-length rel inside the predicate
+                     * (`(a)-[*..]-(b)`) needs a recursive reachability CTE,
+                     * not the single-hop join the legacy emitter below
+                     * produces. Handle that shape first; fall through
+                     * otherwise. */
+                    if (emit_exists_varlen_path(ctx, path)) {
+                        append_sql(ctx, ")");
+                        return 0;
+                    }
 
                     /* Simple pattern like (n)-[r]->(m) */
                     if (path->elements && path->elements->count >= 1) {

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -14,6 +14,25 @@
 #include "parser/cypher_debug.h"
 
 /* Forward declarations */
+/* I-0047 P3: accumulate a bound-rel OPTIONAL endpoint constraint to be flushed
+ * onto the last LEFT JOIN's ON after the path loop (see pending_optional_on). */
+static void transform_ctx_append_pending_optional_on(cypher_transform_context *ctx,
+                                                     const char *cond)
+{
+    if (!ctx || !cond || !cond[0]) return;
+    if (!ctx->pending_optional_on) {
+        ctx->pending_optional_on = strdup(cond);
+        return;
+    }
+    size_t old_len = strlen(ctx->pending_optional_on);
+    size_t add_len = strlen(cond) + 6; /* " AND " + NUL */
+    char *grown = realloc(ctx->pending_optional_on, old_len + add_len);
+    if (!grown) return;
+    strcat(grown, " AND ");
+    strcat(grown, cond);
+    ctx->pending_optional_on = grown;
+}
+
 static int transform_match_pattern(cypher_transform_context *ctx, ast_node *pattern, bool optional);
 static int generate_node_match(cypher_transform_context *ctx, cypher_node_pattern *node, const char *alias, bool optional);
 static int generate_relationship_match(cypher_transform_context *ctx, cypher_rel_pattern *rel,
@@ -678,6 +697,16 @@ handle_where_clause:
         } else if (ctx->sql_buffer) {
             ctx->sql_buffer[0] = '\0';
         }
+    }
+
+    /* I-0047 P3: flush any stashed bound-rel OPTIONAL endpoint constraint onto
+     * the last LEFT JOIN's ON (the fresh target node's join, now emitted).
+     * Runs whether or not a WHERE clause was present (Match7 [4],
+     * MatchWhere6 [5]). */
+    if (ctx->pending_optional_on) {
+        sql_join_append_on(ctx->unified_builder, ctx->pending_optional_on);
+        free(ctx->pending_optional_on);
+        ctx->pending_optional_on = NULL;
     }
 
     /* Clear current graph after MATCH processing */
@@ -2114,7 +2143,27 @@ skip_target_node_join:
                 snprintf(cond, sizeof(cond), "%s = %s AND %s = %s",
                          src_id_ref, src_subq, tgt_id_ref, tgt_subq);
             }
-            sql_where(ctx->unified_builder, cond);
+            /* I-0047 P3: for OPTIONAL MATCH the bound-rel endpoint constraints
+             * are part of the optional pattern; emitting them as WHERE filters
+             * the preserved anchor row (Match7 [4], MatchWhere6 [5]: a bound
+             * rel reused in the reverse direction). Stash them to flush onto
+             * the target node's LEFT JOIN ON after the path loop. Guard: this
+             * only works when exactly *one* endpoint is fresh (the other in
+             * outer scope from a prior clause). If both are fresh, the first
+             * is CROSS-joined and over-produces (Match7 [5]); if both are
+             * bound, there's no fresh LEFT JOIN to attach to. */
+            bool src_in_scope = source_node->variable && (
+                transform_var_is_bound(ctx->var_ctx, source_node->variable) ||
+                transform_var_alias_is_id(ctx->var_ctx, source_node->variable));
+            bool tgt_in_scope = target_node->variable && (
+                transform_var_is_bound(ctx->var_ctx, target_node->variable) ||
+                transform_var_alias_is_id(ctx->var_ctx, target_node->variable));
+            bool exactly_one_fresh = (src_in_scope != tgt_in_scope);
+            if (optional && exactly_one_fresh) {
+                transform_ctx_append_pending_optional_on(ctx, cond);
+            } else {
+                sql_where(ctx->unified_builder, cond);
+            }
 
             /* If the new pattern specifies a relationship type, enforce it
              * against the bound edge's type. `MATCH ()-[r:T]->() WITH r

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -1886,22 +1886,47 @@ static int generate_relationship_match(cypher_transform_context *ctx, cypher_rel
         }
 
 skip_target_node_join:
-        /* Add label constraints for target node if specified */
+        /* Add label constraints for target node if specified.
+         *
+         * I-0047 P3: for OPTIONAL + varlen with a DEFERRED target
+         * (`OPTIONAL MATCH (a)-[:T*]->(c:Label)` where c is unbound), the
+         * target is LEFT-joined later via `c.id = cte.end_id`. Emitting the
+         * label as a separate INNER node_labels join here (a) references the
+         * not-yet-joined target alias and (b) drops the anchor row when the
+         * optional doesn't match. Instead, fold the label into the deferred
+         * target's LEFT JOIN ON as a correlated EXISTS (built below). */
+        char deferred_tgt_label_cond[512] = "";
         if (has_labels(target_node)) {
             const char *target_id = get_node_id_ref(ctx, target_alias, target_node->variable);
 
-            for (int i = 0; i < target_node->labels->count; i++) {
-                const char *label = get_label_string(target_node->labels->items[i]);
-                if (label) {
-                    char nl_alias[64];
-                    snprintf(nl_alias, sizeof(nl_alias), "_nl_%s_%d", target_alias, i);
-                    dbuf_init(&on_cond);
-                    { char *esc_label = escape_sql_string(label);
-                      dbuf_appendf(&on_cond, "%s.node_id = %s AND %s.label = '%s'",
-                                   nl_alias, target_id, nl_alias, esc_label ? esc_label : label);
-                      free(esc_label); }
-                    sql_join(ctx->unified_builder, SQL_JOIN_INNER, get_graph_table(ctx, "node_labels"), nl_alias, dbuf_get(&on_cond));
-                    dbuf_free(&on_cond);
+            if (optional && tgt_deferred) {
+                for (int i = 0; i < target_node->labels->count; i++) {
+                    const char *label = get_label_string(target_node->labels->items[i]);
+                    if (!label) continue;
+                    char *esc_label = escape_sql_string(label);
+                    char one[256];
+                    snprintf(one, sizeof(one),
+                        " AND EXISTS (SELECT 1 FROM %s WHERE node_id = %s AND label = '%s')",
+                        get_graph_table(ctx, "node_labels"), target_id,
+                        esc_label ? esc_label : label);
+                    free(esc_label);
+                    strncat(deferred_tgt_label_cond, one,
+                            sizeof(deferred_tgt_label_cond) - strlen(deferred_tgt_label_cond) - 1);
+                }
+            } else {
+                for (int i = 0; i < target_node->labels->count; i++) {
+                    const char *label = get_label_string(target_node->labels->items[i]);
+                    if (label) {
+                        char nl_alias[64];
+                        snprintf(nl_alias, sizeof(nl_alias), "_nl_%s_%d", target_alias, i);
+                        dbuf_init(&on_cond);
+                        { char *esc_label = escape_sql_string(label);
+                          dbuf_appendf(&on_cond, "%s.node_id = %s AND %s.label = '%s'",
+                                       nl_alias, target_id, nl_alias, esc_label ? esc_label : label);
+                          free(esc_label); }
+                        sql_join(ctx->unified_builder, SQL_JOIN_INNER, get_graph_table(ctx, "node_labels"), nl_alias, dbuf_get(&on_cond));
+                        dbuf_free(&on_cond);
+                    }
                 }
             }
         }
@@ -2013,9 +2038,10 @@ skip_target_node_join:
                         (strlen(js0) >= slen &&
                          strcmp(js0 + strlen(js0) - slen, suffix) == 0))) already = true;
             if (!already) {
-                char tgt_cond[256];
+                char tgt_cond[768];
                 snprintf(tgt_cond, sizeof(tgt_cond),
-                         "%s.id = %s.end_id", target_alias, edge_alias);
+                         "%s.id = %s.end_id%s", target_alias, edge_alias,
+                         deferred_tgt_label_cond);
                 sql_join(ctx->unified_builder, SQL_JOIN_LEFT,
                          get_graph_table(ctx, "nodes"), target_alias, tgt_cond);
             }

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -1556,18 +1556,41 @@ static int generate_node_match(cypher_transform_context *ctx, cypher_node_patter
         /* Get proper node id reference (handles projected variables from WITH) */
         const char *node_id = get_node_id_ref(ctx, alias, node->variable);
 
-        for (int i = 0; i < node->labels->count; i++) {
-            const char *label = get_label_string(node->labels->items[i]);
-            if (label) {
-                char nl_alias[64];
-                snprintf(nl_alias, sizeof(nl_alias), "_nl_%s_%d", alias, i);
-                dbuf_init(&on_cond);
-                { char *esc_label = escape_sql_string(label);
-                  dbuf_appendf(&on_cond, "%s.node_id = %s AND %s.label = '%s'",
-                               nl_alias, node_id, nl_alias, esc_label ? esc_label : label);
-                  free(esc_label); }
-                sql_join(ctx->unified_builder, SQL_JOIN_INNER, get_graph_table(ctx, "node_labels"), nl_alias, dbuf_get(&on_cond));
-                dbuf_free(&on_cond);
+        if (optional) {
+            /* I-0047 P3: an OPTIONAL node's label constraint must be inlined
+             * into the node's own LEFT JOIN ON (as a correlated EXISTS), not
+             * emitted as a separate INNER node_labels join. An INNER join
+             * drops the preserved anchor row whenever the optional pattern
+             * doesn't match (e.g. a second `OPTIONAL MATCH (b:Missing)` after
+             * a null-seeded first optional). The first-node-no-FROM path above
+             * already inlines; this covers every other optional node. */
+            for (int i = 0; i < node->labels->count; i++) {
+                const char *label = get_label_string(node->labels->items[i]);
+                if (!label) continue;
+                char *esc_label = escape_sql_string(label);
+                char cond[512];
+                /* sql_join_append_on prepends " AND " itself. */
+                snprintf(cond, sizeof(cond),
+                    "EXISTS (SELECT 1 FROM %s WHERE node_id = %s AND label = '%s')",
+                    get_graph_table(ctx, "node_labels"), node_id,
+                    esc_label ? esc_label : label);
+                free(esc_label);
+                sql_join_append_on(ctx->unified_builder, cond);
+            }
+        } else {
+            for (int i = 0; i < node->labels->count; i++) {
+                const char *label = get_label_string(node->labels->items[i]);
+                if (label) {
+                    char nl_alias[64];
+                    snprintf(nl_alias, sizeof(nl_alias), "_nl_%s_%d", alias, i);
+                    dbuf_init(&on_cond);
+                    { char *esc_label = escape_sql_string(label);
+                      dbuf_appendf(&on_cond, "%s.node_id = %s AND %s.label = '%s'",
+                                   nl_alias, node_id, nl_alias, esc_label ? esc_label : label);
+                      free(esc_label); }
+                    sql_join(ctx->unified_builder, SQL_JOIN_INNER, get_graph_table(ctx, "node_labels"), nl_alias, dbuf_get(&on_cond));
+                    dbuf_free(&on_cond);
+                }
             }
         }
     }

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -998,8 +998,9 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                             /* Post-WITH node/edge - alias IS the id value */
                             if (transform_var_is_edge(ctx->var_ctx, id->name)) {
                                 /* Edge that passed through WITH - build relationship object */
-                                /* Note: After WITH, we only have the id, not type/source/target */
-                                append_sql(ctx, "json_object("
+                                /* Note: After WITH, we only have the id, not type/source/target.
+                                 * Guard for NULL (OPTIONAL miss carried across WITH). */
+                                append_sql(ctx, "(CASE WHEN %s IS NULL THEN NULL ELSE json_object("
                                     "'id', %s, "
                                     "'type', (SELECT type FROM edges WHERE id = %s), "
                                     "'startNodeId', (SELECT source_id FROM edges WHERE id = %s), "
@@ -1017,13 +1018,17 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                         "EXISTS (SELECT 1 FROM edge_props_bool WHERE edge_id = %s AND key_id = pk.id) OR "
                                         "EXISTS (SELECT 1 FROM edge_props_json WHERE edge_id = %s AND key_id = pk.id)"
                                     "), json('{}'))"
-                                ")",
-                                alias, alias, alias, alias,
+                                ") END)",
+                                alias, alias, alias, alias, alias,
                                 alias, alias, alias, alias, alias,
                                 alias, alias, alias, alias, alias);
                             } else {
-                                /* Node that passed through WITH - build node object using id directly */
-                                append_sql(ctx, "json_object("
+                                /* Node that passed through WITH - build node object using id directly.
+                                 * Guard for NULL (the id column can be NULL when the value came
+                                 * through an OPTIONAL MATCH miss carried across WITH, e.g.
+                                 * Match7 [27]); otherwise json_object('id', NULL, …) renders a
+                                 * bogus non-null node instead of SQL NULL. */
+                                append_sql(ctx, "(CASE WHEN %s IS NULL THEN NULL ELSE json_object("
                                     "'id', %s, "
                                     "'labels', COALESCE((SELECT json_group_array(label) FROM node_labels WHERE node_id = %s), json('[]')), "
                                     "'properties', COALESCE((SELECT json_group_object(pk.key, COALESCE("
@@ -1039,8 +1044,8 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                         "EXISTS (SELECT 1 FROM node_props_bool WHERE node_id = %s AND key_id = pk.id) OR "
                                         "EXISTS (SELECT 1 FROM node_props_json WHERE node_id = %s AND key_id = pk.id)"
                                     "), json('{}'))"
-                                ")",
-                                alias, alias,
+                                ") END)",
+                                alias, alias, alias,
                                 alias, alias, alias, alias, alias,
                                 alias, alias, alias, alias, alias);
                             }

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -837,7 +837,16 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                         CYPHER_DEBUG("Processing path variable '%s' in RETURN", id->name);
                         /* This is a path variable - generate JSON with element IDs */
                         transform_var *path_var = transform_var_lookup_path(ctx->var_ctx, id->name);
-                        if (path_var && path_var->path_elements) {
+                        /* I-0047 P4: a path forwarded through WITH has its
+                         * table_alias set to the CTE column holding the already-
+                         * hydrated path text (a `_with_N.p` column ref). Emit that
+                         * column directly — the element aliases used to rebuild
+                         * the path are out of scope in the outer query. The
+                         * executor still hydrates it via path_elements (With1 [4]). */
+                        if (path_var && path_var->table_alias &&
+                            strchr(path_var->table_alias, '.') != NULL) {
+                            append_sql(ctx, "%s", path_var->table_alias);
+                        } else if (path_var && path_var->path_elements) {
                             CYPHER_DEBUG("Found path variable metadata for '%s' with %d elements", id->name, path_var->path_elements->count);
 
                             /* Check if this is a variable-length path (shortestPath, etc.).

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -1066,7 +1066,15 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                              * edge JSON per id, in path order. */
                             transform_var *evar = transform_var_lookup_edge(ctx->var_ctx, id->name);
                             if (evar && evar->cte_name) {
+                                /* I-0047 P4: guard for an OPTIONAL varlen miss.
+                                 * When the path didn't match, the CTE alias's
+                                 * elem_ids is NULL; json_each(NULL) yields no
+                                 * rows and json_group_array() returns '[]' (an
+                                 * empty array), but openCypher wants NULL for an
+                                 * unmatched OPTIONAL relationship list
+                                 * (Match9 [9]). */
                                 append_sql(ctx,
+                                  "(CASE WHEN %s.elem_ids IS NULL THEN NULL ELSE "
                                   "(SELECT json_group_array(json_object("
                                     "'id', e.id, "
                                     "'type', e.type, "
@@ -1087,8 +1095,8 @@ int transform_expression(cypher_transform_context *ctx, ast_node *expr)
                                       "), json('{}'))"
                                   ") ORDER BY je.key) "
                                   "FROM json_each('[' || %s.elem_ids || ']') je "
-                                  "JOIN edges e ON e.id = je.value WHERE (je.key %% 2) = 1)",
-                                  alias);
+                                  "JOIN edges e ON e.id = je.value WHERE (je.key %% 2) = 1) END)",
+                                  alias, alias);
                                 goto edge_alias_projection_done;
                             }
                             /* Edge variable - return full relationship object,

--- a/src/backend/transform/transform_with.c
+++ b/src/backend/transform/transform_with.c
@@ -396,6 +396,29 @@ int transform_with_clause(cypher_transform_context *ctx, cypher_with *with)
         /* Get the expression as SQL */
         if (item->expr->type == AST_NODE_IDENTIFIER) {
             cypher_identifier *id = (cypher_identifier*)item->expr;
+            /* I-0047 P4: a path variable has no table alias; emit its
+             * hydration SQL (transform_expression handles path vars, building
+             * `'[' || …ids… ']'`) AS the column so the path survives the WITH
+             * boundary. Without this it fell through to a bare `p` column →
+             * "no such column: p" (With1 [4]). The post-CTE registration maps
+             * the path var to a projected `_with_N.p` for the outer scope. */
+            if (transform_var_is_path(ctx->var_ctx, id->name)) {
+                const char *col_name = item->alias ? item->alias : id->name;
+                char *psql = transform_expression_to_string(ctx, item->expr);
+                char idbuf[128];
+                if (psql && psql[0]) {
+                    dbuf_appendf(&col_buf, "%s AS %s", psql,
+                                 sql_ident(idbuf, sizeof(idbuf), col_name));
+                    if (group_count > 0) dbuf_append(&group_buf, ", ");
+                    dbuf_append(&group_buf, psql);
+                    group_count++;
+                } else {
+                    dbuf_appendf(&col_buf, "'[]' AS %s",
+                                 sql_ident(idbuf, sizeof(idbuf), col_name));
+                }
+                free(psql);
+                continue;
+            }
             const char *alias = transform_var_get_alias(ctx->var_ctx, id->name);
             if (alias) {
                 /* Determine column name */
@@ -729,6 +752,12 @@ with_star_columns_done:
     int saved_var_count = 0;
     char **saved_var_names = NULL;
     var_kind *saved_var_kinds = NULL;
+    /* I-0047 P4: preserve path-variable metadata (elements + type) across the
+     * var-ctx reset so a forwarded path var (`MATCH p=… WITH p …`) can be
+     * re-registered as a path pointing at the CTE column, and the executor
+     * still hydrates the stored text into a path object (With1 [4]). */
+    ast_list **saved_path_elems = NULL;
+    var_path_type *saved_path_types = NULL;
 
     if (with->pass_all) {
         /* WITH * - save all visible variable names and kinds */
@@ -748,6 +777,8 @@ with_star_columns_done:
     } else if (with->items && with->items->count > 0) {
         source_kinds = calloc(with->items->count, sizeof(var_kind));
         inner_kinds = calloc(with->items->count, sizeof(var_kind));
+        saved_path_elems = calloc(with->items->count, sizeof(ast_list*));
+        saved_path_types = calloc(with->items->count, sizeof(var_path_type));
         if (source_kinds) {
             for (int i = 0; i < with->items->count; i++) {
                 cypher_return_item *item = (cypher_return_item*)with->items->items[i];
@@ -757,6 +788,10 @@ with_star_columns_done:
                     transform_var *var = transform_var_lookup(ctx->var_ctx, id->name);
                     if (var) {
                         source_kinds[i] = var->kind;
+                        if (var->kind == VAR_KIND_PATH && saved_path_elems) {
+                            saved_path_elems[i] = var->path_elements;
+                            saved_path_types[i] = var->path_type;
+                        }
                     } else {
                         source_kinds[i] = VAR_KIND_PROJECTED;
                     }
@@ -862,7 +897,17 @@ with_star_columns_done:
                            sql_ident(_idbuf, sizeof(_idbuf), col_name)); }
 
                 var_kind kind = source_kinds ? source_kinds[i] : VAR_KIND_PROJECTED;
-                if (kind == VAR_KIND_NODE) {
+                if (kind == VAR_KIND_PATH) {
+                    /* I-0047 P4: re-register the forwarded path as a path var
+                     * whose table_alias is the CTE column holding the already-
+                     * hydrated path text. transform_expression's path branch
+                     * emits that column directly (it has a '.') and the
+                     * executor hydrates it via the preserved path_elements. */
+                    transform_var_register_path(ctx->var_ctx, col_name, select_expr,
+                                                saved_path_elems ? saved_path_elems[i] : NULL,
+                                                saved_path_types ? saved_path_types[i] : VAR_PATH_NORMAL);
+                    CYPHER_DEBUG("WITH: Registered path variable '%s' -> %s", col_name, select_expr);
+                } else if (kind == VAR_KIND_NODE) {
                     transform_var_register_node(ctx->var_ctx, col_name, select_expr, NULL);
                     transform_var_set_alias_is_id(ctx->var_ctx, col_name, true);
                     CYPHER_DEBUG("WITH: Registered node variable '%s' -> %s (alias_is_id)", col_name, select_expr);
@@ -913,6 +958,8 @@ with_star_columns_done:
     /* Free saved kinds array */
     free(source_kinds);
     free(inner_kinds);
+    free(saved_path_elems);
+    free(saved_path_types);
 
     /* Handle WHERE clause (applied after projection) — only if the pre-WITH
      * translation didn't succeed (i.e., the WHERE references projected

--- a/src/include/transform/cypher_transform.h
+++ b/src/include/transform/cypher_transform.h
@@ -59,7 +59,14 @@ struct cypher_transform_context {
     char *pending_prop_joins;
     size_t pending_prop_joins_len;
     size_t pending_prop_joins_cap;
-    
+
+    /* I-0047 P3: bound-rel endpoint constraint for an OPTIONAL MATCH, stashed
+     * by the rel handler and flushed onto the last LEFT JOIN's ON after the
+     * path loop (when the fresh target node's join exists). Emitting it inline
+     * as WHERE would filter the preserved anchor row (Match7 [4],
+     * MatchWhere6 [5]: a bound rel reused in the reverse direction). Owned. */
+    char *pending_optional_on;
+
     /* Query type tracking */
     enum {
         QUERY_TYPE_UNKNOWN,


### PR DESCRIPTION
Initiative **GQLITE-I-0047** — Pattern & Path Matching Completeness. **3684 → 3698 (+14 TCK), zero regressions** (every commit verified by a full pass-set diff; unit 944/944 + functional clean throughout).

## Clusters
- **P1 (T-0334) — done, +6:** undirected variable-length CTE (both orientations), MATCH+DELETE `count(*)` decoupled from delete-count, varlen inside WHERE `EXISTS`-pattern predicates.
- **P2 (T-0335) — done, +1:** inline relationship property predicate on varlen rels. (Disproved the multi-segment premise — chains already match; filed MATCH+CREATE first-row-only write-path bug as T-0339.)
- **P3 (T-0336) — partial, +5:** OPTIONAL row preservation (varlen anchor; node labels inline into LEFT JOIN ON); varlen relationship-uniqueness (not node-uniqueness); null-guard for WITH-projected NULL node/edge in RETURN.
- **P4 (T-0337) — done, +2:** forward a path variable through WITH (With1 [4]); OPTIONAL varlen named-path/relationship-list returns NULL not `[]` on no-match (Match9 [9]).

## Scenarios fixed
Match9 [1]/[3]/[9]/[12]/[15]/[21]/[27], Delete4 [1], Pattern1 [10]/[17]/[18], Match4 [5], Aggregation5 [2], With1 [4].

## Remaining (documented deeper refactors, deferred)
- P3 multi-rel OPTIONAL combined-EXISTS join ordering → derived-table rewrite (MatchWhere6 [7], Match7 [4]).
- P3 bound-rel reverse OPTIONAL → deferred-constraint plumbing.
- P5 (T-0338) MATCH+MERGE re-match → AST-mutation/SET untangling.
- T-0339 — MATCH+CREATE only processes the first matched row (write-path).

Coverage recorded in `docs/testing/semantic-coverage-matrix.md`; per-cluster analysis in the GQLITE-T-033x tasks.