### PR TITLE
T-0339: MATCH+CREATE multi-row + general expressions in CREATE props (+3 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -262,3 +262,26 @@ HEAD, zero regressions; unit 944/944; functional clean):
   Fixes Match9 [9].
 
 P4 (GQLITE-T-0337) complete: +2 (With1 [4], Match9 [9]).
+
+## Coverage update (2026-05-28) — T-0339: MATCH+CREATE multi-row + general expressions
+
+GQLITE-T-0339 (backlog bug). Verified via the TCK harness (full pass-set diff,
+zero regressions; unit 944/944; functional clean):
+
+- **`MATCH … CREATE …` now runs the CREATE for every matched row.** The
+  legacy single-MATCH path took only the first matched row (hard-coded
+  `break` in `bind_match_clause_into_varmap`). Now `execute_multi_match_create_query`
+  materializes all matched rows into memory BEFORE running CREATE (running
+  CREATE inside `sqlite3_step` invalidates the iterating SELECT), allocates a
+  fresh `var_map` per row so CREATE-introduced bindings don't bleed across
+  rows, and iterates every CREATE clause's patterns per row.
+- **`CREATE (n {prop: <expr>})` evaluates general expressions** referencing
+  MATCH-bound variables (e.g. `{name: d.name + '0'}`). Previously the prop
+  handler only knew LITERAL / FUNCTION_CALL / MAP/LIST / PARAMETER values; a
+  general-expression fallback now calls `executor_eval_value` with the current
+  `var_map`.
+
+Together these fix Match5 [25]/[28]/[29] (the setups that build a per-D `E`
+layer with computed names). Multi-MATCH MATCH+CREATE keeps the legacy
+first-row behavior pending a separate fix. Match5 [26] (MATCH+DELETE+CREATE
+setup) and Match4 [4] (UNWIND/collect setup) need distinct follow-ups.

--- a/src/backend/executor/executor_create.c
+++ b/src/backend/executor/executor_create.c
@@ -340,6 +340,37 @@ int execute_path_pattern_with_variables(cypher_executor *executor, cypher_path *
                                         }
                                     }
                                     property_value_free(&func_pv);
+                                } else {
+                                    /* GQLITE-T-0339 (part 2): general expression
+                                     * (e.g. `d.name + '0'` where d is a MATCH-bound
+                                     * node). Evaluate via executor_eval_value with
+                                     * the current var_map so property access and
+                                     * arithmetic/concatenation resolve. */
+                                    property_value gen_pv;
+                                    property_value_init(&gen_pv);
+                                    int erc = executor_eval_value(executor, pair->value, var_map, &prop_type, &gen_pv);
+                                    if (erc == 0) {
+                                        static int64_t gen_int_buf;
+                                        static double gen_real_buf;
+                                        static int gen_bool_buf;
+                                        if (prop_type == PROP_TYPE_TEXT || prop_type == PROP_TYPE_JSON) {
+                                            if (cypher_schema_set_node_property(executor->schema_mgr, node_id, pair->key, prop_type, gen_pv.as_str) == 0) {
+                                                result->properties_set++;
+                                            }
+                                            property_value_free(&gen_pv);
+                                            continue;
+                                        } else if (prop_type == PROP_TYPE_INTEGER) {
+                                            gen_int_buf = gen_pv.as_int;
+                                            prop_value = &gen_int_buf;
+                                        } else if (prop_type == PROP_TYPE_REAL) {
+                                            gen_real_buf = gen_pv.as_real;
+                                            prop_value = &gen_real_buf;
+                                        } else if (prop_type == PROP_TYPE_BOOLEAN) {
+                                            gen_bool_buf = gen_pv.as_bool;
+                                            prop_value = &gen_bool_buf;
+                                        }
+                                    }
+                                    property_value_free(&gen_pv);
                                 }
 
                                 if (prop_value) {
@@ -521,6 +552,34 @@ int execute_path_pattern_with_variables(cypher_executor *executor, cypher_path *
                                         }
                                     }
                                     property_value_free(&func_pv2);
+                                } else {
+                                    /* GQLITE-T-0339 (part 2): general expression
+                                     * referencing MATCH-bound vars (e.g. `d.name + '0'`). */
+                                    property_value gen_pv2;
+                                    property_value_init(&gen_pv2);
+                                    int erc = executor_eval_value(executor, pair->value, var_map, &prop_type, &gen_pv2);
+                                    if (erc == 0) {
+                                        static int64_t gen_int_buf2;
+                                        static double gen_real_buf2;
+                                        static int gen_bool_buf2;
+                                        if (prop_type == PROP_TYPE_TEXT || prop_type == PROP_TYPE_JSON) {
+                                            if (cypher_schema_set_node_property(executor->schema_mgr, target_node_id, pair->key, prop_type, gen_pv2.as_str) == 0) {
+                                                result->properties_set++;
+                                            }
+                                            property_value_free(&gen_pv2);
+                                            continue;
+                                        } else if (prop_type == PROP_TYPE_INTEGER) {
+                                            gen_int_buf2 = gen_pv2.as_int;
+                                            prop_value = &gen_int_buf2;
+                                        } else if (prop_type == PROP_TYPE_REAL) {
+                                            gen_real_buf2 = gen_pv2.as_real;
+                                            prop_value = &gen_real_buf2;
+                                        } else if (prop_type == PROP_TYPE_BOOLEAN) {
+                                            gen_bool_buf2 = gen_pv2.as_bool;
+                                            prop_value = &gen_bool_buf2;
+                                        }
+                                    }
+                                    property_value_free(&gen_pv2);
                                 }
 
                                 if (prop_value) {

--- a/src/backend/executor/executor_match.c
+++ b/src/backend/executor/executor_match.c
@@ -955,27 +955,196 @@ int execute_multi_match_create_query(cypher_executor *executor, cypher_query *qu
         set_result_error(result, "Failed to create variable map");
         return -1;
     }
-
-    for (int i = 0; i < query->clauses->count; i++) {
-        ast_node *clause = query->clauses->items[i];
-        if (!clause || clause->type != AST_NODE_MATCH) continue;
-        if (bind_match_clause_into_varmap(executor, (cypher_match*)clause, var_map, result) < 0) {
-            free_variable_map(var_map);
-            return -1;
-        }
-    }
-
     if (!create->pattern) {
         set_result_error(result, "No pattern in CREATE clause");
         free_variable_map(var_map);
         return -1;
     }
-    for (int i = 0; i < create->pattern->count; i++) {
-        ast_node *pattern = create->pattern->items[i];
-        if (pattern->type == AST_NODE_PATH) {
-            if (execute_path_pattern_with_variables(executor, (cypher_path*)pattern, result, var_map) < 0) {
+
+    /* Count MATCH clauses to detect the single-MATCH case (the common shape). */
+    int match_count = 0;
+    cypher_match *single_match = NULL;
+    for (int i = 0; i < query->clauses->count; i++) {
+        ast_node *c = query->clauses->items[i];
+        if (c && c->type == AST_NODE_MATCH) {
+            match_count++;
+            if (!single_match) single_match = (cypher_match*)c;
+        }
+    }
+
+    /* GQLITE-T-0339: legacy code took only the first matched row (a hard-coded
+     * `break` in bind_match_clause_into_varmap), so MATCH (d:D) CREATE (e:E)
+     * created exactly one `e` regardless of how many D nodes existed. For the
+     * single-MATCH case run the MATCH inline, materialize ALL matched rows
+     * into memory (executing CREATE during sqlite3_step invalidates the
+     * iterating SELECT — observed: only the first row processed), then
+     * iterate the captured rows running EVERY CREATE clause's patterns per
+     * row. A fresh row_vm per row keeps CREATE-introduced bindings (e, g, …)
+     * from bleeding across rows. Multi-MATCH keeps the legacy first-row
+     * behavior (a separate, larger fix). */
+    if (match_count == 1 && single_match) {
+        cypher_transform_context *ctx = cypher_transform_create_context(executor->db);
+        if (!ctx) {
+            set_result_error(result, "Failed to create transform context");
+            free_variable_map(var_map);
+            return -1;
+        }
+        if (transform_match_clause(ctx, single_match) < 0) {
+            set_result_error(result, ctx && ctx->error_message ? ctx->error_message : "Failed to transform MATCH");
+            cypher_transform_free_context(ctx);
+            free_variable_map(var_map);
+            return -1;
+        }
+        if (finalize_sql_generation(ctx) < 0) {
+            set_result_error(result, "Failed to finalize SQL generation");
+            cypher_transform_free_context(ctx);
+            free_variable_map(var_map);
+            return -1;
+        }
+        /* Replace SELECT * with explicit node/edge id selection. */
+        char *select_pos = strstr(ctx->sql_buffer, "SELECT *");
+        if (select_pos) {
+            char *after_star = select_pos + strlen("SELECT *");
+            char *temp = strdup(after_star);
+            ctx->sql_size = select_pos + strlen("SELECT ") - ctx->sql_buffer;
+            ctx->sql_buffer[ctx->sql_size] = '\0';
+            bool first_col = true;
+            int vcount = transform_var_count(ctx->var_ctx);
+            for (int i = 0; i < vcount; i++) {
+                transform_var *var = transform_var_at(ctx->var_ctx, i);
+                if (var && (var->kind == VAR_KIND_NODE || var->kind == VAR_KIND_EDGE)) {
+                    if (!first_col) append_sql(ctx, ", ");
+                    append_sql(ctx, "%s.id AS \"%s_id\"", var->table_alias, var->name);
+                    first_col = false;
+                }
+            }
+            append_sql(ctx, " %s", temp);
+            free(temp);
+        }
+        sqlite3_stmt *stmt = NULL;
+        int rc_prep = sqlite3_prepare_v2(executor->db, ctx->sql_buffer, -1, &stmt, NULL);
+        if (rc_prep != SQLITE_OK) {
+            char err[512];
+            snprintf(err, sizeof(err), "MATCH SQL prepare failed: %s", sqlite3_errmsg(executor->db));
+            set_result_error(result, err);
+            cypher_transform_free_context(ctx);
+            free_variable_map(var_map);
+            return -1;
+        }
+        if (executor->params_json && bind_params_from_json(stmt, executor->params_json) < 0) {
+            set_result_error(result, "Failed to bind query parameters");
+            sqlite3_finalize(stmt);
+            cypher_transform_free_context(ctx);
+            free_variable_map(var_map);
+            return -1;
+        }
+        /* Materialize all matched rows BEFORE any CREATE. */
+        int vcount2 = transform_var_count(ctx->var_ctx);
+        int rows_cap = 16, rows_n = 0;
+        int64_t **row_ids = malloc(rows_cap * sizeof(int64_t*));
+        if (!row_ids) {
+            set_result_error(result, "OOM (row id buffer)");
+            sqlite3_finalize(stmt);
+            cypher_transform_free_context(ctx);
+            free_variable_map(var_map);
+            return -1;
+        }
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            if (rows_n == rows_cap) {
+                rows_cap *= 2;
+                int64_t **g = realloc(row_ids, rows_cap * sizeof(int64_t*));
+                if (!g) {
+                    set_result_error(result, "OOM (row grow)");
+                    for (int k = 0; k < rows_n; k++) free(row_ids[k]);
+                    free(row_ids);
+                    sqlite3_finalize(stmt);
+                    cypher_transform_free_context(ctx);
+                    free_variable_map(var_map);
+                    return -1;
+                }
+                row_ids = g;
+            }
+            row_ids[rows_n] = malloc(vcount2 * sizeof(int64_t));
+            int col = 0;
+            for (int i = 0; i < vcount2; i++) {
+                transform_var *var = transform_var_at(ctx->var_ctx, i);
+                if (var && (var->kind == VAR_KIND_NODE || var->kind == VAR_KIND_EDGE)) {
+                    row_ids[rows_n][i] = sqlite3_column_int64(stmt, col++);
+                } else {
+                    row_ids[rows_n][i] = -1;
+                }
+            }
+            rows_n++;
+        }
+        sqlite3_finalize(stmt);
+
+        /* Now run CREATEs per row with a fresh var_map (the placeholder is
+         * discarded since the loop builds replacements). */
+        free_variable_map(var_map);
+        var_map = NULL;
+        for (int r = 0; r < rows_n; r++) {
+            variable_map *row_vm = create_variable_map();
+            if (!row_vm) {
+                set_result_error(result, "Failed to create row var_map");
+                for (int k = 0; k < rows_n; k++) free(row_ids[k]);
+                free(row_ids);
+                cypher_transform_free_context(ctx);
+                if (var_map) free_variable_map(var_map);
+                return -1;
+            }
+            for (int i = 0; i < vcount2; i++) {
+                transform_var *var = transform_var_at(ctx->var_ctx, i);
+                if (!var) continue;
+                if (var->kind == VAR_KIND_NODE) {
+                    set_variable_node_id(row_vm, var->name, (int)row_ids[r][i]);
+                } else if (var->kind == VAR_KIND_EDGE) {
+                    set_variable_edge_id(row_vm, var->name, (int)row_ids[r][i]);
+                }
+            }
+            /* Every CREATE clause's patterns for this row. */
+            for (int ci = 0; ci < query->clauses->count; ci++) {
+                ast_node *cclause = query->clauses->items[ci];
+                if (!cclause || cclause->type != AST_NODE_CREATE) continue;
+                cypher_create *cc = (cypher_create*)cclause;
+                if (!cc->pattern) continue;
+                for (int i = 0; i < cc->pattern->count; i++) {
+                    ast_node *pattern = cc->pattern->items[i];
+                    if (pattern->type == AST_NODE_PATH) {
+                        if (execute_path_pattern_with_variables(executor, (cypher_path*)pattern, result, row_vm) < 0) {
+                            free_variable_map(row_vm);
+                            for (int k = 0; k < rows_n; k++) free(row_ids[k]);
+                            free(row_ids);
+                            cypher_transform_free_context(ctx);
+                            if (var_map) free_variable_map(var_map);
+                            return -1;
+                        }
+                    }
+                }
+            }
+            if (var_map) free_variable_map(var_map);
+            var_map = row_vm;
+        }
+        for (int k = 0; k < rows_n; k++) free(row_ids[k]);
+        free(row_ids);
+        cypher_transform_free_context(ctx);
+        if (!var_map) var_map = create_variable_map(); /* no matched rows */
+    } else {
+        /* Multi-MATCH (or zero-MATCH) legacy path: first-row-only binding. */
+        for (int i = 0; i < query->clauses->count; i++) {
+            ast_node *clause = query->clauses->items[i];
+            if (!clause || clause->type != AST_NODE_MATCH) continue;
+            if (bind_match_clause_into_varmap(executor, (cypher_match*)clause, var_map, result) < 0) {
                 free_variable_map(var_map);
                 return -1;
+            }
+        }
+        for (int i = 0; i < create->pattern->count; i++) {
+            ast_node *pattern = create->pattern->items[i];
+            if (pattern->type == AST_NODE_PATH) {
+                if (execute_path_pattern_with_variables(executor, (cypher_path*)pattern, result, var_map) < 0) {
+                    free_variable_map(var_map);
+                    return -1;
+                }
             }
         }
     }


### PR DESCRIPTION
**GQLITE-T-0339 (backlog bug):** `MATCH+CREATE` only processed the first matched row (hard-coded `break`). Two coordinated fixes land:

### Part 1 — multi-row iteration (a063b69)
`execute_multi_match_create_query`, single-MATCH path:
- materialize **all** matched rows into memory BEFORE running CREATE (running CREATE inside `sqlite3_step` invalidates the iterating SELECT — observed: only the first row processed);
- per-row fresh `var_map` so CREATE-introduced bindings (`e`, `g`, …) don't bleed across rows;
- iterate **every** CREATE clause's patterns per row (queries like `MATCH (d) CREATE (g) CREATE (d)-[:R]->(g)` have two CREATE clauses).

### Part 2 — general expressions in CREATE prop values (f5938a7)
CREATE prop handlers only knew LITERAL / FUNCTION_CALL / MAP/LIST / PARAMETER. Added an else-fallback that calls `executor_eval_value` with the current `var_map`, so expressions like `{name: d.name + '0'}` resolve.

## Verification
- Probe: `MATCH (d:D) CREATE (e:E {name: d.name + '0'})` produces 1 e per matched d with the computed name.
- **+3 TCK** (Match5 [25]/[28]/[29]), full pass-set diff vs HEAD, **zero regressions**; unit 944/944; functional clean.

## Remaining (separate fixes)
- Match5 [26] — setup uses MATCH+DELETE+CREATE (multi-row DELETE path).
- Match4 [4] — UNWIND+collect setup, unrelated.
- Multi-MATCH MATCH+CREATE (rare) keeps legacy first-row behavior.