### PR TITLE
T-0339 part 3: MATCH+DELETE+CREATE runs the CREATE per matched row (+1 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -283,5 +283,10 @@ zero regressions; unit 944/944; functional clean):
 
 Together these fix Match5 [25]/[28]/[29] (the setups that build a per-D `E`
 layer with computed names). Multi-MATCH MATCH+CREATE keeps the legacy
-first-row behavior pending a separate fix. Match5 [26] (MATCH+DELETE+CREATE
-setup) and Match4 [4] (UNWIND/collect setup) need distinct follow-ups.
+first-row behavior pending a separate fix.
+
+**Part 3 — `MATCH … DELETE … CREATE …` now runs the CREATE.**
+`handle_match_delete` dropped the CREATE clause entirely. It now runs CREATE
+first (per matched row via `execute_multi_match_create_query`) with the live
+pre-delete bindings, then proceeds with the delete. Fixes Match5 [26].
+Match4 [4] (UNWIND/collect setup) needs a distinct follow-up.

--- a/src/backend/executor/query_dispatch.c
+++ b/src/backend/executor/query_dispatch.c
@@ -799,8 +799,23 @@ static int handle_match_delete(cypher_executor *executor, cypher_query *query,
 {
     cypher_match *match = find_match_clause(query);
     cypher_delete *del = find_delete_clause(query);
+    cypher_create *cre = find_create_clause(query);
 
     CYPHER_DEBUG("Executing MATCH+DELETE via pattern dispatch");
+
+    /* T-0339 (part 3): MATCH+DELETE+CREATE — handle_match_delete previously
+     * dropped the CREATE clause entirely. Run CREATE first (per matched row,
+     * via execute_multi_match_create_query which iterates every row) using
+     * the live pre-delete bindings; then proceed with the delete. The new
+     * relationships/nodes from CREATE don't depend on the entities being
+     * deleted, so this ordering preserves Cypher semantics for the in-scope
+     * scenarios (Match5 [26] setup: rewires (a)-[r]->(b) by creating
+     * (b)-[:LIKES]->(a) and deleting r). */
+    if (cre) {
+        if (execute_multi_match_create_query(executor, query, cre, result, NULL) < 0) {
+            return -1;
+        }
+    }
 
     /* T-0321: MATCH+DELETE+RETURN — capture the RETURN projection
      * BEFORE delete when the projection references entity data


### PR DESCRIPTION
**Follow-up to T-0339** (#77 part 1+2 already merged).

\`handle_match_delete\` dropped the CREATE clause entirely for queries like:
\`\`\`cypher
MATCH (a:A)-[r]->(b) DELETE r CREATE (b)-[:LIKES]->(a)
\`\`\`

When a CREATE clause is present, the handler now runs it **first** — per matched row, via \`execute_multi_match_create_query\` (the multi-row iterator from #77) — using the live pre-delete bindings, then proceeds with the delete. The new entities created by CREATE don't depend on the entities being deleted (in scope), so this ordering preserves Cypher semantics for the in-scope scenarios.

Verified probe: \`MATCH (a:A)-[r:T]->(b) DELETE r CREATE (b)-[:LIKES]->(a)\` now creates 1 LIKES rel and deletes 1 T rel.

**Fixes Match5 [26].** Zero TCK regressions (full pass-set diff). 3702 → 3703. Unit 944/944, functional clean.