### PR TITLE
validate+match: rel-uniqueness validator + dedupe edges-table emission (correctness, +0 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -302,3 +302,18 @@ Match4 [4] (UNWIND/collect setup) needs a distinct follow-up.
   inside function calls / property access / subscripts. New recursive helper
   `expr_contains_path_pattern` walks the expression tree and the SET validator
   invokes it. Fixes Pattern1 [24].
+
+## Coverage update (2026-05-28) — validate+match: rel-uniqueness + dedupe edges-table emission
+
+Architectural correctness fix (zero TCK delta; zero regressions; unit 944/944;
+functional clean):
+
+- **New `validate_rel_uniqueness_in_match` validator** — a relationship
+  variable may not appear twice within the same MATCH pattern
+  (`MATCH (a)-[r]->()-[r]->(a)` → `SyntaxError:
+  RelationshipUniquenessViolation`). Cross-clause re-use is allowed
+  (binding-then-reuse) and unchanged.
+- **Dedupe `edges AS <alias>` emission across MATCH clauses** — re-emitting an
+  already-joined alias was the masquerading SyntaxError that Match3 [29]
+  relied on; the validator above is now the explicit check. Match4 [7] no
+  longer errors (still fails on a distinct over-counting bug, follow-up).

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -2472,7 +2472,21 @@ skip_target_node_join:
                 }
             }
 
-            sql_join(ctx->unified_builder, SQL_JOIN_LEFT, get_graph_table(ctx, "edges"), edge_alias, dbuf_get(&edge_cond));
+            /* T-0339 follow-up: skip the edges join if this alias is already
+             * in scope from a prior MATCH clause (Match4 [7]). Same-pattern
+             * re-use is now caught at validate-time
+             * (RelationshipUniquenessViolation, Match3 [29]). */
+            {
+                const char *fs0 = dbuf_get(&ctx->unified_builder->from);
+                const char *js0 = dbuf_get(&ctx->unified_builder->joins);
+                char needle[80];
+                snprintf(needle, sizeof(needle), "AS %s", edge_alias);
+                bool already = (fs0 && strstr(fs0, needle)) ||
+                               (js0 && strstr(js0, needle));
+                if (!already) {
+                    sql_join(ctx->unified_builder, SQL_JOIN_LEFT, get_graph_table(ctx, "edges"), edge_alias, dbuf_get(&edge_cond));
+                }
+            }
             dbuf_free(&edge_cond);
 
             /* T-0320: emit deferred source-node LEFT JOIN tied through
@@ -2548,8 +2562,19 @@ skip_target_node_join:
                 }
             }
         } else {
-            /* Non-optional: use CROSS JOIN for edges (will be filtered by WHERE) */
-            sql_join(ctx->unified_builder, SQL_JOIN_CROSS, get_graph_table(ctx, "edges"), edge_alias, NULL);
+            /* Non-optional: use CROSS JOIN for edges (will be filtered by WHERE).
+             * T-0339 follow-up: skip if this alias is already in scope from
+             * a prior MATCH clause (Match4 [7]). Same-pattern re-use is
+             * caught at validate-time (Match3 [29]). */
+            const char *fs0 = dbuf_get(&ctx->unified_builder->from);
+            const char *js0 = dbuf_get(&ctx->unified_builder->joins);
+            char needle[80];
+            snprintf(needle, sizeof(needle), "AS %s", edge_alias);
+            bool already = (fs0 && strstr(fs0, needle)) ||
+                           (js0 && strstr(js0, needle));
+            if (!already) {
+                sql_join(ctx->unified_builder, SQL_JOIN_CROSS, get_graph_table(ctx, "edges"), edge_alias, NULL);
+            }
         }
     }
     

--- a/src/backend/transform/transform_validate.c
+++ b/src/backend/transform/transform_validate.c
@@ -1934,6 +1934,40 @@ static int validate_write_no_null_props(ast_list *patterns, const char *kw,
 /* CREATE / MERGE must use a single explicit relationship type, no
  * multi-type (`[:T1|T2]`), and no variable-length range. MATCH allows
  * all of those — this validator is only for writes. */
+/* T-0339 follow-up: a relationship variable may not be re-used within the
+ * same MATCH pattern. `MATCH (a)-[r]->()-[r]->(a)` is a SyntaxError —
+ * "RelationshipUniquenessViolation" (Match3 [29]). Cross-clause re-use
+ * (`MATCH …-[r]-… MATCH …-[r]-…`) is allowed (binding-then-reuse). */
+static int validate_rel_uniqueness_in_match(ast_list *patterns, char **error_message)
+{
+    if (!patterns) return 0;
+    name_set seen; nset_init(&seen);
+    for (int pi = 0; pi < patterns->count; pi++) {
+        ast_node *pn = patterns->items[pi];
+        if (!pn || pn->type != AST_NODE_PATH) continue;
+        cypher_path *p = (cypher_path *)pn;
+        if (!p->elements) continue;
+        for (int ei = 0; ei < p->elements->count; ei++) {
+            ast_node *el = p->elements->items[ei];
+            if (!el || el->type != AST_NODE_REL_PATTERN) continue;
+            cypher_rel_pattern *rp = (cypher_rel_pattern *)el;
+            if (!rp->variable) continue;
+            if (nset_contains(&seen, rp->variable)) {
+                set_error(error_message,
+                          "SyntaxError: RelationshipUniquenessViolation: "
+                          "Cannot use the same relationship variable `%s` "
+                          "for multiple patterns",
+                          rp->variable);
+                nset_free(&seen);
+                return -1;
+            }
+            nset_add(&seen, rp->variable);
+        }
+    }
+    nset_free(&seen);
+    return 0;
+}
+
 static int validate_write_rel_patterns(ast_list *patterns, const char *kw,
                                        char **error_message)
 {
@@ -2190,6 +2224,10 @@ int transform_validate_query(cypher_query *query, char **error_message)
             }
             case AST_NODE_MATCH: {
                 cypher_match *m = (cypher_match *)clause;
+                /* T-0339 follow-up: a relationship variable may not appear
+                 * twice within the SAME MATCH pattern (Match3 [29]). */
+                rc = validate_rel_uniqueness_in_match(m->pattern, error_message);
+                if (rc != 0) break;
                 /* Register the MATCH pattern's variable types BEFORE
                  * validating its WHERE expression, so type-aware checks
                  * (e.g. "WHERE n where n is a node") can see n's type. */


### PR DESCRIPTION
**Coupled architectural correctness fix** requested as a follow-up to Match4 [7]'s "ambiguous column" error.

Two changes that together replace an *accidental* correctness pathway with a deliberate one:

### 1) New `validate_rel_uniqueness_in_match` validator
A relationship variable may not appear twice within the same MATCH pattern:
\`\`\`cypher
MATCH (a)-[r]->()-[r]->(a) RETURN r
-- SyntaxError: RelationshipUniquenessViolation
\`\`\`
openCypher cross-clause re-use (\`MATCH …-[r]-… MATCH …-[r]-…\`) is allowed (binding-then-reuse) and not flagged. Caught at MATCH-clause validation before the same-pattern duplicate reaches SQL generation.

### 2) Skip duplicate \`edges AS <alias>\` emission across MATCH clauses
Match4 [7]: \`MATCH ()-[r:EDGE]-() MATCH …()-[r]-()…\` previously hit SQLite with two \`edges AS _gql_default_alias_0\` joins → "ambiguous column name". The error masquerading as a SyntaxError was the *only* reason Match3 [29] still passed; the validator above is now the explicit check, so the skip is safe.

## TCK delta: +0 (zero regressions)
Match3 [29] still passes — via the correct path now. Match4 [7] no longer errors but still fails on over-counting (84 vs expected 32) — a distinct multi-MATCH + bound-rel-in-varlen counting bug, deferred as a separate follow-up.

Unit 944/944, functional clean. Full pass-set diff confirms zero regressions.