### PR TITLE
match: path-wide rel-uniqueness for non-optional varlen vs bound rels (+1 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -317,3 +317,18 @@ functional clean):
   already-joined alias was the masquerading SyntaxError that Match3 [29]
   relied on; the validator above is now the explicit check. Match4 [7] no
   longer errors (still fails on a distinct over-counting bug, follow-up).
+
+## Coverage update (2026-05-28) — path-wide rel-uniqueness across varlen and bound rels
+
+`transform_match.c`. Verified via the TCK harness (full pass-set diff, zero
+regressions; unit 944/944; functional clean):
+
+- **Varlen segments may not re-use a path's bound non-varlen relationship.** The
+  existing path-wide rel-uniqueness block already paired non-varlen edge aliases
+  (`e_i.id <> e_j.id`). It now also enforces `<varlen>.visited NOT LIKE
+  '%,<bound_rel.id>,%'` against each non-varlen rel in the same path — both
+  table-aliased (`<alias>.id`) and post-WITH (`_with_0.r`) forms. The constraint
+  is only emitted for **non-OPTIONAL** paths; OPTIONAL needs the constraint at
+  the LEFT JOIN ON level to preserve the anchor row (deferred). Cross-varlen
+  disjointness is also deferred (no failing scenario requires it). Fixes
+  Match4 [7].

--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -1331,6 +1331,72 @@ skip_combined_exists:
                 sql_where(ctx->unified_builder, where_buf);
             }
         }
+
+        /* T-0339 follow-up: extend path-wide rel-uniqueness across varlen
+         * segments — each varlen's `visited` (the comma-separated edge ids
+         * it traversed) must not include any non-varlen rel id used by the
+         * same path. Without this, `MATCH …()-[r]-()-[*0..1]-(m)` would
+         * count varlen paths that re-use the bound r (Match4 [7]: 84 → 32).
+         * Cross-varlen disjointness is a further refinement; not yet
+         * implemented (no current TCK scenario depends on it). */
+        const char *varlen_aliases[16];
+        int n_varlen = 0;
+        if (js) {
+            const char *p = js;
+            while ((p = strstr(p, "_varlen_path_")) != NULL && n_varlen < 16) {
+                const char *as = strstr(p, " AS ");
+                if (!as) break;
+                as += 4;
+                const char *end = as;
+                while (*end && (isalnum((unsigned char)*end) || *end == '_')) end++;
+                if (end > as) {
+                    /* dup the alias substring into a small static pool so
+                     * its lifetime spans the WHERE emission. */
+                    static char pool[16][80];
+                    static int pool_idx = 0;
+                    int slot = pool_idx++ % 16;
+                    size_t alen = (size_t)(end - as);
+                    if (alen >= sizeof(pool[slot])) alen = sizeof(pool[slot]) - 1;
+                    memcpy(pool[slot], as, alen);
+                    pool[slot][alen] = '\0';
+                    varlen_aliases[n_varlen++] = pool[slot];
+                }
+                p = end;
+            }
+        }
+        /* Emit as a WHERE constraint, ONLY when the current path is NOT
+         * optional. For OPTIONAL MATCH a WHERE constraint on the varlen
+         * filters the preserved-anchor row when the varlen unexpectedly
+         * matched something (Match7 [19]); a proper ON-level filter requires
+         * deeper join-builder work and is deferred. */
+        if (!optional) {
+            for (int vi = 0; vi < n_varlen; vi++) {
+                for (int ei = 0; ei < n_edges; ei++) {
+                    char where_buf[320];
+                    snprintf(where_buf, sizeof(where_buf),
+                        "%s.visited NOT LIKE '%%,' || CAST(%s.id AS TEXT) || ',%%'",
+                        varlen_aliases[vi], edge_aliases[ei]);
+                    sql_where(ctx->unified_builder, where_buf);
+                }
+            }
+            for (int vi = 0; vi < n_varlen; vi++) {
+                for (int i = 0; i < path->elements->count; i++) {
+                    ast_node *el = path->elements->items[i];
+                    if (el->type != AST_NODE_REL_PATTERN) continue;
+                    cypher_rel_pattern *r = (cypher_rel_pattern *)el;
+                    if (r->varlen) continue;
+                    if (!r->variable) continue;
+                    if (!transform_var_alias_is_id(ctx->var_ctx, r->variable)) continue;
+                    const char *colref = transform_var_get_alias(ctx->var_ctx, r->variable);
+                    if (!colref) continue;
+                    char where_buf[320];
+                    snprintf(where_buf, sizeof(where_buf),
+                        "%s.visited NOT LIKE '%%,' || CAST(%s AS TEXT) || ',%%'",
+                        varlen_aliases[vi], colref);
+                    sql_where(ctx->unified_builder, where_buf);
+                }
+            }
+        }
     }
 
     free(defer_to_rel);


### PR DESCRIPTION
For \`MATCH ()-[r:EDGE]-() MATCH p = (n)-[*0..1]-()-[r]-()-[*0..1]-(m)\` (Match4 [7]) the varlen segments must not re-use the bound rel \`r\`. Without path-wide rel-uniqueness across varlens, our count was **84 vs expected 32** — varlen 1-hops re-used the same edge as the bound rel slot.

## Fix
Extended the existing path-wide rel-uniqueness block (which already pairs non-varlen edge aliases with \`e_i.id <> e_j.id\`) to also enforce
\`\`\`sql
<varlen>.visited NOT LIKE '%,<bound_rel.id>,%'
\`\`\`
against each non-varlen rel in the same path. Both table-aliased rels (\`<alias>.id\`) and post-WITH bound rels whose alias IS the id column ref (e.g. \`_with_0.r\`).

## OPTIONAL guard
Only emit when the path is NOT optional. For OPTIONAL the WHERE constraint would filter the preserved-anchor row when the varlen unexpectedly matched something (caught Match7 [19] regressing in an interim attempt). A proper ON-level filter requires deeper join-builder work and is deferred.

Cross-varlen disjointness (two varlen segments sharing an edge) is also deferred — no current TCK scenario depends on it.

## Verification
**Fixes Match4 [7].** Zero TCK regressions (full pass-set diff). 3704 → 3705. Unit 944/944, functional clean.