### PR TITLE
remove: treat REMOVE on null/unbound variable as a no-op (+1 TCK)

### DIFF
--- a/.metis/code-index.md
+++ b/.metis/code-index.md
@@ -1,6 +1,6 @@
 # Code Index
 
-> Generated: 2026-05-23T04:00:06Z | 73 files | JavaScript, Python, Rust
+> Generated: 2026-05-28T21:30:36Z | 73 files | JavaScript, Python, Rust
 
 ## Project Structure
 

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -332,3 +332,18 @@ regressions; unit 944/944; functional clean):
   the LEFT JOIN ON level to preserve the anchor row (deferred). Cross-varlen
   disjointness is also deferred (no failing scenario requires it). Fixes
   Match4 [7].
+
+## Coverage update (2026-05-28) — REMOVE on null/unbound variable is a no-op
+
+`executor_remove.c`. Verified via the TCK harness (3705 -> 3706, zero
+regressions; unit 944/944; functional clean):
+
+- **REMOVE on a null variable yields no side effect** (matches Cypher semantics
+  and SET parity). `MATCH (n) OPTIONAL MATCH (n)-[r]->() REMOVE r.num` previously
+  errored with `"Unbound variable in REMOVE: r"` because `is_variable_edge()`
+  returns false for absent map entries (the OPTIONAL preserves the row but
+  doesn't bind `r`), so the rel fell through to the node path's `entity_id < 0`
+  error. Both `entity_id < 0` branches in `execute_remove_operations` now log a
+  debug line and `continue`, treating the REMOVE item as a no-op. The existing
+  "property not found on this entity" path was already silent — this aligns
+  null-variable behavior with that. Fixes Remove1 [6].

--- a/src/backend/executor/executor_remove.c
+++ b/src/backend/executor/executor_remove.c
@@ -209,10 +209,10 @@ int execute_remove_operations(cypher_executor *executor, cypher_remove *remove, 
         if (is_edge) {
             entity_id = get_variable_edge_id(var_map, var_id->name);
             if (entity_id < 0) {
-                char error[256];
-                snprintf(error, sizeof(error), "Unbound edge variable in REMOVE: %s", var_id->name);
-                set_result_error(result, error);
-                return -1;
+                /* Cypher semantics: REMOVE on a null/unbound variable is a no-op
+                 * (Remove1 [6]). Matches the parallel node behavior below. */
+                CYPHER_DEBUG("REMOVE on null/unbound edge variable '%s' (no-op)", var_id->name);
+                continue;
             }
 
             /* Delete the property from the edge */
@@ -226,10 +226,12 @@ int execute_remove_operations(cypher_executor *executor, cypher_remove *remove, 
         } else {
             entity_id = get_variable_node_id(var_map, var_id->name);
             if (entity_id < 0) {
-                char error[256];
-                snprintf(error, sizeof(error), "Unbound variable in REMOVE: %s", var_id->name);
-                set_result_error(result, error);
-                return -1;
+                /* Cypher semantics: REMOVE on a null/unbound variable is a no-op.
+                 * Also covers the case where an OPTIONAL-bound edge variable falls
+                 * through to the node path because is_variable_edge() returns false
+                 * for absent entries (Remove1 [6]). */
+                CYPHER_DEBUG("REMOVE on null/unbound variable '%s' (no-op)", var_id->name);
+                continue;
             }
 
             /* Delete the property from the node */


### PR DESCRIPTION
For \`MATCH (n) OPTIONAL MATCH (n)-[r]->() REMOVE r.num\` (Remove1 [6]) the outer MATCH preserves the row, the OPTIONAL fails to match (no rel exists), so \`r\` is unbound on that row. \`is_variable_edge()\` returns false for absent map entries — sending us into the node branch where \`get_variable_node_id()\` returned -1 and we raised \`"Unbound variable in REMOVE: r"\`.

## Cypher semantics
REMOVE on a null variable yields **no side effect** (parallels SET on null, and the existing 'property not found on entity' silent path in this same function). Remove1 [5] (\`OPTIONAL MATCH (a:DoesNotExist) REMOVE a.num\`) already passes for the same reason.

## Fix
Both \`entity_id < 0\` branches in \`execute_remove_operations\` (edge and node) now \`CYPHER_DEBUG\` and \`continue\` instead of erroring.

## Verification
**Fixes Remove1 [6].** Zero TCK regressions; full Remove pass-set still 100%. 3705 → 3706. Unit 944/944, functional clean.