### PR TITLE
parser: accept bidirectional bracketed rel pattern <-[...]-> (correctness, +0 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -347,3 +347,16 @@ regressions; unit 944/944; functional clean):
   debug line and `continue`, treating the REMOVE item as a no-op. The existing
   "property not found on this entity" path was already silent — this aligns
   null-variable behavior with that. Fixes Remove1 [6].
+
+## Coverage update (2026-05-28) — accept bidirectional bracketed rel pattern `<-[...]->`
+
+`cypher_gram.y`. Verified via the TCK harness (3706 -> 3706 pass; one scenario
+moves from `error` -> `fail` as parse now succeeds; full unit + functional clean):
+
+- **Grammar accepts `<-[...]->` form** as equivalent to undirected `-[...]-`
+  (Match5 [27] and any future scenario using both arrows on a bracketed rel).
+  Five rules added to mirror the existing five `-[...]-` undirected forms
+  (var-only, IDENTIFIER, BQIDENT, non_reserved_kw type, multi-type list); each
+  passes `false/false` for `(left_arrow, right_arrow)` to `make_rel_pattern_varlen`.
+  Bare bidirectional `<-->` was already supported. Match5 [27] still fails
+  downstream on bidirectional varlen execution semantics; that fix is deferred.

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -951,6 +951,34 @@ rel_pattern:
             if (p) p->varlen = (ast_node*)$7;
             $$ = p;
         }
+    /* Bidirectional bracketed: <-[...]-> (Match5 [27]) — equivalent to
+     * undirected `-[...]-`. Per openCypher, both arrows present means "any
+     * direction"; pass false/false to make_rel_pattern_varlen. */
+    | '<' '-' '[' variable_opt varlen_range_opt properties_opt ']' '-' '>'
+        {
+            $$ = make_rel_pattern_varlen($4, NULL, (ast_node*)$6, false, false, (ast_node*)$5);
+        }
+    | '<' '-' '[' variable_opt ':' IDENTIFIER varlen_range_opt properties_opt ']' '-' '>'
+        {
+            $$ = make_rel_pattern_varlen($4, $6, (ast_node*)$8, false, false, (ast_node*)$7);
+            free($6);
+        }
+    | '<' '-' '[' variable_opt ':' BQIDENT varlen_range_opt properties_opt ']' '-' '>'
+        {
+            $$ = make_rel_pattern_varlen($4, $6, (ast_node*)$8, false, false, (ast_node*)$7);
+            free($6);
+        }
+    | '<' '-' '[' variable_opt ':' non_reserved_kw varlen_range_opt properties_opt ']' '-' '>'
+        {
+            $$ = make_rel_pattern_varlen($4, $6, (ast_node*)$8, false, false, (ast_node*)$7);
+            free($6);
+        }
+    | '<' '-' '[' variable_opt ':' rel_type_list varlen_range_opt properties_opt ']' '-' '>'
+        {
+            cypher_rel_pattern *p = make_rel_pattern_multi_type($4, $6, (ast_node*)$8, false, false);
+            if (p) p->varlen = (ast_node*)$7;
+            $$ = p;
+        }
     /* Undirected relationships: -[...]- */
     | '-' '[' variable_opt varlen_range_opt properties_opt ']' '-'
         {


### PR DESCRIPTION
\`MATCH (a)-[:LIKES]->()<-[:LIKES*3]->(c)\` (Match5 [27]) raised \`"unexpected '>', expecting '('"\` because the grammar only accepted \`<-[...]-\` (left), \`-[...]->\` (right), \`-[...]-\` (undirected). The bidirectional bracketed form \`<-[...]->\` is valid Cypher — openCypher accepts it, and bare \`<-->\` is already accepted in this grammar.

## Fix
Added five mirror rules for \`<-[...]->\`: var-only, IDENTIFIER type, BQIDENT type, non_reserved_kw type, and multi-type list. Each passes \`false/false\` for left/right arrows (treated as undirected, matching how bare \`<-->\` is interpreted).

No bison conflicts (still \`%expect 15\` / \`%expect-rr 3\`).

## Verification
- The previously-errored Match5 [27] now parses cleanly. It still fails downstream on bidirectional varlen execution semantics — deferred to a future change.
- Net TCK pass unchanged at 3706; one scenario moves from \`error\` to \`fail\`.
- Unit 944/944, functional clean.

This is a parser-correctness PR (matches the +0 TCK, correctness-only pattern of #80) — accepts more valid Cypher syntax without affecting any passing scenario.