### PR TITLE
return: RETURN * skips named-path anon element prefixes _pv_n/_pv_e (+1 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -360,3 +360,16 @@ moves from `error` -> `fail` as parse now succeeds; full unit + functional clean
   passes `false/false` for `(left_arrow, right_arrow)` to `make_rel_pattern_varlen`.
   Bare bidirectional `<-->` was already supported. Match5 [27] still fails
   downstream on bidirectional varlen execution semantics; that fix is deferred.
+
+## Coverage update (2026-05-28) — RETURN * skips named-path anon element prefixes
+
+`executor_match.c` + `transform_return.c`. Verified via the TCK harness
+(3706 -> 3707, zero regressions; unit 944/944; functional clean):
+
+- **`RETURN *` after `MATCH p = (a)-->(b)` exposes only `a, b, p`**, not the
+  synthesized rel alias. When a path is named (`p = ...`), anonymous path
+  elements get synthesized variable names with prefixes `_pv_n<base>_<j>`
+  (nodes) and `_pv_e<base>_<j>` (rels). The two `RETURN *` expansion sites
+  (`executor_match.c` and `transform_return.c`) already skipped the older
+  `_gql_default_alias_` and `__unnamed_rel_` prefixes; both now also skip
+  `_pv_n` / `_pv_e`. Fixes Return7 [1].

--- a/src/backend/executor/executor_match.c
+++ b/src/backend/executor/executor_match.c
@@ -99,9 +99,13 @@ int execute_match_return_query(cypher_executor *executor, cypher_match *match, c
             transform_var *var = transform_var_at(ctx->var_ctx, vi);
             if (!var || !var->is_visible || !var->name) continue;
             /* RETURN * exposes only user-named variables, not synthetic
-             * aliases for anonymous nodes/rels (With1 [1]/[2]). */
+             * aliases for anonymous nodes/rels (With1 [1]/[2]).
+             * Named paths additionally synthesize `_pv_n<base>_<j>` /
+             * `_pv_e<base>_<j>` for their anonymous path elements (Return7 [1]). */
             if (strncmp(var->name, "_gql_default_alias_", 19) == 0 ||
-                strncmp(var->name, "__unnamed_rel_", 14) == 0) continue;
+                strncmp(var->name, "__unnamed_rel_", 14) == 0 ||
+                strncmp(var->name, "_pv_n", 5) == 0 ||
+                strncmp(var->name, "_pv_e", 5) == 0) continue;
             /* Create an identifier node referencing this variable */
             ast_node *id_node = (ast_node*)make_identifier(strdup(var->name), -1);
             if (id_node) {

--- a/src/backend/transform/transform_return.c
+++ b/src/backend/transform/transform_return.c
@@ -295,9 +295,13 @@ int transform_return_clause(cypher_transform_context *ctx, cypher_return *ret)
                 transform_var *var = transform_var_at(ctx->var_ctx, vi);
                 if (!var || !var->is_visible || !var->name) continue;
                 /* RETURN * exposes only user-named variables, not the synthetic
-                 * aliases generated for anonymous nodes/rels (With1 [1]/[2]). */
+                 * aliases generated for anonymous nodes/rels (With1 [1]/[2]).
+                 * Named paths additionally synthesize `_pv_n<base>_<j>` /
+                 * `_pv_e<base>_<j>` for their anonymous path elements (Return7 [1]). */
                 if (strncmp(var->name, "_gql_default_alias_", 19) == 0 ||
-                    strncmp(var->name, "__unnamed_rel_", 14) == 0) continue;
+                    strncmp(var->name, "__unnamed_rel_", 14) == 0 ||
+                    strncmp(var->name, "_pv_n", 5) == 0 ||
+                    strncmp(var->name, "_pv_e", 5) == 0) continue;
 
                 /* Build expression for this variable based on its kind */
                 if (var->kind == VAR_KIND_NODE) {


### PR DESCRIPTION
\`MATCH p = (a:Start)-->(b) RETURN *\` (Return7 [1]) returned 4 columns (\`p, a, b, _pv_e0_1\`) when the spec wants 3 (\`a, b, p\`).

## Cause
When a path is named, \`transform_match.c\` assigns synthesized variable names \`_pv_n<base>_<j>\` (nodes) and \`_pv_e<base>_<j>\` (rels) to the path's anonymous elements so the path projection can reference them. The two \`RETURN *\` expansion sites (\`executor_match.c\` and \`transform_return.c\`) already skipped the older \`_gql_default_alias_\` and \`__unnamed_rel_\` prefixes — they missed the \`_pv_\` family.

## Fix
Both skip lists now also skip \`_pv_n\` and \`_pv_e\` (5-char prefix check, same pattern as the existing entries).

## Verification
**Fixes Return7 [1].** Zero TCK regressions. 3706 → 3707. Unit 944/944, functional clean.