### PR TITLE
parser: four-label conjunction in expression context (+1 TCK)

### DIFF
--- a/.metis/code-index.md
+++ b/.metis/code-index.md
@@ -1,6 +1,6 @@
 # Code Index
 
-> Generated: 2026-05-28T21:30:36Z | 73 files | JavaScript, Python, Rust
+> Generated: 2026-05-29T02:14:00Z | 73 files | JavaScript, Python, Rust
 
 ## Project Structure
 

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -373,3 +373,15 @@ moves from `error` -> `fail` as parse now succeeds; full unit + functional clean
   (`executor_match.c` and `transform_return.c`) already skipped the older
   `_gql_default_alias_` and `__unnamed_rel_` prefixes; both now also skip
   `_pv_n` / `_pv_e`. Fixes Return7 [1].
+
+## Coverage update (2026-05-28) — four-label conjunction in expression context
+
+`cypher_gram.y`. Verified via the TCK harness (3707 -> 3708, zero regressions;
+unit 944/944; functional clean):
+
+- **`WHERE a:L1:L2:L3:L4` parses** as the conjunction `(a:L1) AND (a:L2) AND
+  (a:L3) AND (a:L4)` (Graph5 [4], e.g. `a:C:A:A:C`). The `expr`-context label
+  rules already covered 1/2/3 labels; the four-label form raised a parse error.
+  Added a mirror rule chaining four `make_label_expr` conjuncts. Repeated labels
+  are harmless — each conjunct is an independent EXISTS check. No bison conflicts
+  (still `%expect 15` / `%expect-rr 3`).

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -1384,6 +1384,30 @@ primary_expr:
                                             @1.first_line);
             free($1); free($3); free($5); free($7);
         }
+    | IDENTIFIER ':' IDENTIFIER ':' IDENTIFIER ':' IDENTIFIER ':' IDENTIFIER
+        {
+            /* Four-label conjunction (Graph5 [4], e.g. `a:C:A:A:C`).
+             * Repeated labels are harmless — each conjunct is an
+             * independent EXISTS check. */
+            cypher_identifier *b1 = make_identifier($1, @1.first_line);
+            cypher_identifier *b2 = make_identifier(strdup($1), @1.first_line);
+            cypher_identifier *b3 = make_identifier(strdup($1), @1.first_line);
+            cypher_identifier *b4 = make_identifier(strdup($1), @1.first_line);
+            cypher_label_expr *l1 = make_label_expr((ast_node*)b1, $3, @3.first_line);
+            cypher_label_expr *l2 = make_label_expr((ast_node*)b2, $5, @5.first_line);
+            cypher_label_expr *l3 = make_label_expr((ast_node*)b3, $7, @7.first_line);
+            cypher_label_expr *l4 = make_label_expr((ast_node*)b4, $9, @9.first_line);
+            cypher_binary_op *and12 = make_binary_op(BINARY_OP_AND,
+                                                     (ast_node*)l1, (ast_node*)l2,
+                                                     @1.first_line);
+            cypher_binary_op *and123 = make_binary_op(BINARY_OP_AND,
+                                                      (ast_node*)and12, (ast_node*)l3,
+                                                      @1.first_line);
+            $$ = (ast_node*)make_binary_op(BINARY_OP_AND,
+                                            (ast_node*)and123, (ast_node*)l4,
+                                            @1.first_line);
+            free($1); free($3); free($5); free($7); free($9);
+        }
     ;
 
 literal_expr:


### PR DESCRIPTION
\`MATCH (a) WHERE a:C:A:A:C RETURN a\` (Graph5 [4]) raised a parse error — the \`expr\`-context label-conjunction rules covered 1, 2, and 3 labels but not 4.

openCypher allows arbitrary-length conjunctive label expressions (\`a:L1:L2:...\`), and repeated labels are legal (each is an independent membership check, so \`a:C:A:A:C\` ≡ \`a:A AND a:C\`).

## Fix
Added the four-label \`expr\` rule mirroring the existing three-label one, chaining four \`make_label_expr\` nodes with \`BINARY_OP_AND\`. No bison conflicts (still \`%expect 15\` / \`%expect-rr 3\`).

## Verification
**Fixes Graph5 [4]** (all Scenario Outline examples). Zero TCK regressions. 3707 → 3708. Unit 944/944, functional clean.