### PR TITLE
parser: existential subquery brace form EXISTS { pattern } (+2 TCK)

### DIFF
--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -385,3 +385,17 @@ unit 944/944; functional clean):
   Added a mirror rule chaining four `make_label_expr` conjuncts. Repeated labels
   are harmless — each conjunct is an independent EXISTS check. No bison conflicts
   (still `%expect 15` / `%expect-rr 3`).
+
+## Coverage update (2026-05-28) — existential subquery brace form (no inner WHERE)
+
+`cypher_gram.y`. Verified via the TCK harness (3708 -> 3710, zero regressions;
+unit 944/944; functional clean):
+
+- **`WHERE exists { (n)-->() }` parses and evaluates** (ExistentialSubquery1
+  [1]/[3]). Added `EXISTS '{' pattern_list '}'` reusing the existing
+  `EXISTS_TYPE_PATTERN` transform, which already resolves correlated outer
+  variables (the bound `n`) via its outer-alias lookup and emits a correlated
+  `EXISTS (SELECT 1 FROM ... WHERE ...)` subquery. No bison conflicts (still
+  `%expect 15` / `%expect-rr 3`). The brace form **with** an inner `WHERE`
+  ([2]/[4]) and the full-query/aggregation/nested forms (ExistentialSubquery2/3)
+  remain unsupported — they need inner-variable registration and are deferred.

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -1500,6 +1500,14 @@ function_call:
             /* EXISTS((pattern)) - check for relationship/path existence */
             $$ = (ast_node*)make_exists_pattern_expr($3, @1.first_line);
         }
+    | EXISTS '{' pattern_list '}'
+        {
+            /* Existential subquery brace form: EXISTS { (n)-->() }
+             * (ExistentialSubquery1 [1]/[3]). Reuses the pattern-existence
+             * transform; correlated outer variables resolve via the
+             * EXISTS_TYPE_PATTERN emitter's outer-alias lookup. */
+            $$ = (ast_node*)make_exists_pattern_expr($3, @1.first_line);
+        }
     | EXISTS '(' IDENTIFIER '.' IDENTIFIER ')'
         {
             /* EXISTS(n.property) - unambiguous property existence check */


### PR DESCRIPTION
\`MATCH (n) WHERE exists { (n)-->() } RETURN n\` (ExistentialSubquery1 [1]/[3]) raised a parse error — only the parenthesized \`EXISTS(pattern)\` form was accepted, not the openCypher existential-subquery brace form \`EXISTS { ... }\`.

## Fix
Added \`EXISTS '{' pattern_list '}'\` to the expr grammar, reusing the existing \`make_exists_pattern_expr\` / \`EXISTS_TYPE_PATTERN\` transform. That emitter already handles correlated outer variables — the outer-bound \`n\` resolves via \`transform_var_get_alias\` and is referenced without being added to the subquery FROM, producing \`EXISTS (SELECT 1 FROM ... WHERE ...)\`.

No bison conflicts (still \`%expect 15\` / \`%expect-rr 3\`).

## Scope
No-inner-WHERE form only. The brace form with an inner WHERE ([2]/[4]) and the full-query / aggregation / nested forms (ExistentialSubquery2/3) need inner-variable registration in the subquery scope — deferred to a follow-up.

## Verification
**Fixes ExistentialSubquery1 [1] and [3].** Zero TCK regressions (fail steady at 132). 3708 → 3710. Unit 944/944, functional clean.