### PR TITLE
temporal: close the non-DST Temporal TCK cluster (+30)

### DIFF
--- a/.metis/initiatives/GQLITE-I-0049/initiative.md
+++ b/.metis/initiatives/GQLITE-I-0049/initiative.md
@@ -1,0 +1,83 @@
+---
+id: tck-deep-item-conformance-temporal
+level: initiative
+title: "TCK deep-item conformance (Temporal, Quantifier, Merge, ordering)"
+short_code: "GQLITE-I-0049"
+created_at: 2026-05-30T14:17:28.737710+00:00
+updated_at: 2026-05-30T14:17:28.737710+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: L
+initiative_id: tck-deep-item-conformance-temporal
+---
+
+# TCK deep-item conformance (Temporal, Quantifier, Merge, ordering)
+
+## Context
+
+After the +44-scenario TCK push (PRs #76–#87, main at **3728 pass / 148 non-pass**
+as of 2026-05-30), the remaining gaps are no longer one-line fixes — they cluster
+into a handful of deep, multi-scenario features. This initiative tracks those
+clusters, one task each, so each can be decomposed and ground out independently
+while progress survives compaction.
+
+Baseline: `angreal test tck` → pass=3728 fail=123 error=25 skipped=4.
+Verification gate for every task: rigorous full pass-set diff (zero regressions),
+unit 944/944, functional clean. Work stacks on one branch per the PR-batching
+preference; squash-merge per cluster or per batch as the user directs.
+
+## Goals & Non-Goals
+
+**Goals:**
+- Close the large TCK clusters: Temporal (~42), Quantifier (~30), Merge (~14),
+  ordering/WithOrderBy (~10), with zero regressions.
+- Decompose each cluster into a task with its own root-cause analysis + sub-steps.
+
+**Non-Goals:**
+- Boolean type preservation (architecturally blocked — see memory
+  `boolean_type_preservation_blocked`; SQLite has no bool type / can't bind subtypes).
+- Full rewrites of the value-representation layer.
+
+## Cluster inventory (task-per-cluster)
+
+| Task | Cluster | ~Count | Root cause | Difficulty |
+|------|---------|--------|------------|------------|
+| T-A | Temporal | ~42 | duration arithmetic, duration.between, date selection, parsing, accessors, named TZ | Medium, decomposable |
+| T-B | Quantifier | ~30 | all/any/none/single through the WITH list pipeline | Medium (one root cause may cascade) |
+| T-C | Merge | ~14 | bind path, bound-var reuse, direction, multi-row MATCH+MERGE cartesian iteration | Medium-hard |
+| T-D | WithOrderBy/ordering | ~10 | ORDER BY stability/tie-break across types (refines GQLITE-T-0340 comparator) | Low-medium |
+| T-E | Existential subqueries (2/3) | 5 | full/nested EXISTS { full-query / aggregation / nesting } | Hard |
+| T-F | Write-path list/UNWIND (List12, Pattern2) | 7 | entity-list through SET / pattern-comprehension write path | Hard |
+| T-G | Misc contained singletons | ~6 | smallest-int literal (Literals2/3/4 [8]), varlen path-length (Path3 [1], Path1), runtime TypeErrors (TypeConversion3) | Mixed |
+
+## Recommended sequence
+
+1. **Temporal (T-A)** — biggest, cleanly decomposable, steady high-yield. **STARTING HERE.**
+2. **Quantifier (T-B)** — best count-to-effort; existing analysis in memory `quantifier_equality_dropped`.
+3. **Merge (T-C)** — multi-row MATCH+MERGE iteration unlocks several at once.
+4. **WithOrderBy (T-D)** — small comparator refinement.
+
+## Detailed Design
+
+Per-cluster design lives in each child task. The shared method: (a) enumerate the
+cluster's failing scenarios + diagnostics, (b) find the common root cause(s),
+(c) fix smallest-first, (d) rigorous pass-set diff after each, (e) record findings
+in the task as working memory.
+
+## Implementation Plan
+
+Phase per cluster, in the sequence above. Each cluster task is decomposed into
+sub-steps once started (human check-in before decomposing, per Metis HITL).
+
+## Status
+
+- 2026-05-30: Initiative created. Structure approved (initiative + task-per-cluster).
+  Starting with Temporal (T-A).

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -64,3 +64,32 @@ diff after each (zero regressions); unit 944/944; functional clean. Record findi
 - 2026-05-30: Task created with sub-step breakdown from the failure inventory.
   Baseline main = 3728 pass. Starting analysis with sub-step 1 (Temporal8 duration
   arithmetic) — biggest concentrated win.
+
+### 2026-05-30: Sub-step 1 (Temporal8) deep analysis
+
+Durations are stored as JSON `{"_iso8601","months","days","seconds","nanosecondsOfSecond"}`.
+Reusable runtime helpers in `udf_helpers.c`: `is_duration_value()`, `dur_field_ll()`,
+`emit_duration_json(ctx, months, days, total_ns)` (keeps months/days independent, only
+splits total_ns→seconds+nanos), `apply_duration_to_temporal()`, `format_iso_duration()`.
+ADD/SUB route through `gql_dyn_addsub_func` (`_gql_dyn_add`/`_gql_dyn_sub`), which already
+handles dur+dur and dur+temporal.
+
+Concrete Temporal8 bugs found:
+- **[7] multiply/divide by number → returns `0`.** `BINARY_OP_MUL`/`DIV` in
+  transform_expr_ops.c emit a bare ` * ` / ` / `; SQLite coerces the duration JSON text
+  to 0. FIX: route MUL/DIV through new `_gql_dyn_mul`/`_gql_dyn_div` UDFs (mirror the
+  ADD/SUB dispatch) that detect a duration operand and scale months/days/total_ns by the
+  number (Cypher rounding for non-integer factors TBD — check expected values per example).
+- **[2]-[5] duration ± temporal: wrong values** (e.g. local time off by hours:
+  exp `22:29:27.5` vs act `17:14:54.5`). `apply_duration_to_temporal` mis-applies some
+  components — investigate which (days/seconds vs hours). NOT just formatting.
+- **[6] duration ± duration: wrong values AND wraps as object.** exp `P25Y4M43DT50H...`
+  vs act `{_iso8601:'P25Y4M44DT20H...'}`. Two issues: (a) value differs by ~6h (computation
+  or the test's input durations carry hours we mis-split between days/seconds), (b) the
+  result renders as the full duration object, but the expected is the ISO string — the
+  renderer already extracts `_iso8601` for duration values (udf_helpers.c:905), so check
+  why the arithmetic result loses that path (likely the column type/rendering path).
+
+NEXT (next work session): implement `_gql_dyn_mul`/`_gql_dyn_div` for durations ([7],
+clearest win), then chase the value-computation discrepancy in apply_duration_to_temporal
+([2]-[5]) and dur+dur ([6]). Verify each with rigorous pass-set diff.

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -151,3 +151,16 @@ Remaining Temporal (precise, with root cause for next session):
   (named_tz_offset is a month approximation; these test exact transition days).
 - **Overflow (deferred): Temporal10 [9]/[10] (2)** — int64 overflow in calendar/
   seconds path for billion-year / huge-second durations.
+
+### 2026-05-31: Temporal cluster nearly closed — branch 3758 (+30 vs main 3728)
+
+All non-DST Temporal now passes. Remaining = DST only (12):
+- Temporal10 [8] (8): duration.inSeconds across the 2017-10-29 fall-back —
+  needs across-transition elapsed-time (24 wall hrs = 25 real hrs).
+- Temporal3 [10] (2) / Temporal2 [6] (2): named-zone offset on a DST-transition
+  date (e.g. 1984-03-28 -> +02).
+GOTCHA: named_tz_offset's month approximation (Apr–Sep summer) is LOAD-BEARING.
+A clean last-Sunday-rule rewrite REGRESSED -29 (many passing tests depend on the
+coarse rule). DST must be done empirically/per-date against the TCK's exact
+expectations, NOT a simple rule swap. Recommend PR the +30 branch; tackle DST
+as a separate focused task.

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -126,3 +126,28 @@ Remaining Temporal (next sub-steps):
 - Temporal3 [10] (2): datetime named-tz DST offset (+01 vs +02).
 - Temporal2 parsing (6), Temporal1 [13], Temporal5 [6], Temporal7 [3].
 - Temporal10 DST [8] (5) + large/overflow [9]/[10] (2) — hardest, deferred.
+
+### 2026-05-31: checkpoint — branch i0049-temporal at 3749 (+21 vs main 3728)
+
+Closed this session: Temporal8 (27/27), Temporal10 inMonths/inDays, Temporal3
+quarter selection + time() region-drop, Temporal1 [12], Temporal7 [6].
+7 commits, all rigorous-diff zero-regression, unit 944/944.
+
+Remaining Temporal (precise, with root cause for next session):
+- **Temporal2 [3]/[5]** (2): tz offset `-00:00`/`+00:00` must render as `Z`.
+  Formatting fix in the offset emitters.
+- **Temporal1 [13]** (3 examples): tz offset with seconds — `+02:05:00` -> `+02:05`
+  (drop `:00`), `+02:05:59` -> keep `:59`. Offset parse must retain seconds and
+  the formatter must emit `:SS` only when non-zero. (Currently offsets stored as
+  minutes; need second precision.)
+- **Temporal2 [7]** (2): parse duration FROM string `P22DT19H51M49.5S` — fractional
+  / multi-field ISO duration parse broken (gives P22DT12H / PT0S).
+- **Temporal3 [1] ex8/15** (2): date selection returns None — investigate which
+  selection form (likely week/weekYear combo) crashes.
+- **Temporal5 [6]** (1): datetime accessors (one accessor value off).
+- **Temporal7 [3]** (1): compare times — boolean vector inverted (tz/offset compare).
+- **DST cluster (hard, deferred): Temporal3 [10] (2), Temporal2 [6] (2),
+  Temporal10 [8] (6)** — need real DST-transition handling at named-zone dates
+  (named_tz_offset is a month approximation; these test exact transition days).
+- **Overflow (deferred): Temporal10 [9]/[10] (2)** — int64 overflow in calendar/
+  seconds path for billion-year / huge-second durations.

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -111,3 +111,18 @@ duration.inMonths/inDays now compare time-of-day in UTC when both sides have tz
 DST-aware durations [8] (5 — needs real DST transition handling, hard) and large
 durations [9]/[10] (2 — int overflow in the calendar/seconds path). Deferring DST
 + overflow; next consider Temporal3 (date selection, 9) and Temporal2 (parsing, 6).
+
+### 2026-05-30: Session checkpoint — branch i0049-temporal at 3744 (+16 vs main 3728)
+
+Commits: duration mul/div (+3), fractional construction+date arith (+11),
+inMonths/inDays tz (+2). Temporal8 fully closed (27/27).
+
+Remaining Temporal (next sub-steps):
+- Temporal3 [1] date selection (5): `date({date: other, quarter: N})` must
+  preserve monthOfQuarter + day (we reset to quarter-start month + day 1, giving
+  1984-07-01 vs expected 1984-08-11). Plus week/ordinalDay base-selection forms.
+- Temporal3 [3] time() with named tz (2): `time(...)` must DROP the `[Region]`
+  suffix, keeping only the offset (datetime keeps it; time drops it).
+- Temporal3 [10] (2): datetime named-tz DST offset (+01 vs +02).
+- Temporal2 parsing (6), Temporal1 [13], Temporal5 [6], Temporal7 [3].
+- Temporal10 DST [8] (5) + large/overflow [9]/[10] (2) — hardest, deferred.

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -93,3 +93,21 @@ Concrete Temporal8 bugs found:
 NEXT (next work session): implement `_gql_dyn_mul`/`_gql_dyn_div` for durations ([7],
 clearest win), then chase the value-computation discrepancy in apply_duration_to_temporal
 ([2]-[5]) and dur+dur ([6]). Verify each with rigorous pass-set diff.
+
+### 2026-05-30: Sub-step 1 (Temporal8) COMPLETE — Temporal8 27/27
+
+Two commits (branch i0049-temporal): duration mul/div (+3), fractional construction
++ date arithmetic (+11). Branch 3728 -> 3742. Key learnings (durations are NOT
+normalized across components; 1 month = 30.436875 days, 1 day = 86400 s; only
+date+duration rolls whole-day time into the date). Remaining Temporal:
+Temporal10 (10, duration.between + DST), Temporal3 (9, date selection),
+Temporal2 (6, parsing), Temporal1 [13]/Temporal5 [6]/Temporal7 [3] (1 each).
+NEXT: Temporal10 duration.between.
+
+### 2026-05-30: Sub-step 2 (Temporal10) partial — inMonths/inDays tz fix (+2)
+
+duration.inMonths/inDays now compare time-of-day in UTC when both sides have tz
+(Temporal10 [3] ex19, [4] ex17). Branch 3742 -> 3744. Remaining Temporal10 (8):
+DST-aware durations [8] (5 — needs real DST transition handling, hard) and large
+durations [9]/[10] (2 — int overflow in the calendar/seconds path). Deferring DST
++ overflow; next consider Temporal3 (date selection, 9) and Temporal2 (parsing, 6).

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -164,3 +164,28 @@ A clean last-Sunday-rule rewrite REGRESSED -29 (many passing tests depend on the
 coarse rule). DST must be done empirically/per-date against the TCK's exact
 expectations, NOT a simple rule swap. Recommend PR the +30 branch; tackle DST
 as a separate focused task.
+
+### 2026-06-01: DST cluster — ROOT CAUSE = needs an IANA tz database (NOT closeable by rules)
+
+Dug into the 12 remaining DST scenarios empirically. Findings:
+- **Why the offset approximation is load-bearing / risky:** `named_tz_offset` is
+  called from many paths (construction, parsing, duration.between, accessors,
+  rendering). The TCK encodes HISTORICALLY-ACCURATE IANA data, so any rule must
+  match history exactly. A modern "last Sunday of March..October" EU rule
+  REGRESSED -52 examples because pre-1996 EU DST ended the last Sunday of
+  SEPTEMBER (e.g. 1984-10-11 Stockholm = +01:00, not +02:00). The OLD coarse
+  Apr–Sep approximation happens to match those pre-1996 Sept endings.
+- A regression-free improvement IS possible: historical end-month
+  (`(y>=1996)?Oct:Sep`) + threading the real base date into the datetime
+  named-tz offset lookup (`_gql_tz_offset_for(tz, _gql_date_compose(... $.date,
+  $.datetime))`). Verified 0 regressions, and it fixes individual examples
+  (e.g. Temporal3 [10] ex14) — but flips NO full scenario, so net +0. Reverted
+  to keep the +30 branch coherent; re-derive from this note when doing IANA work.
+- **Hard stop:** full DST is impossible without an embedded IANA tz database.
+  Temporal2 [6] expects `1818-07-21 Stockholm = +00:53:28` — Local Mean Time
+  before standardization. No rule produces that. Temporal10 [8] additionally
+  needs across-transition elapsed time (24 wall-clock hrs = 25 real hrs on the
+  fall-back day). Both require the real tzdata.
+- RECOMMENDATION: close T-0341 as "Temporal non-DST done (+30)"; open a separate
+  task "embed IANA tzdata for full temporal DST conformance" (large, data-heavy)
+  for the 12 DST scenarios.

--- a/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
+++ b/.metis/initiatives/GQLITE-I-0049/tasks/GQLITE-T-0341.md
@@ -1,0 +1,66 @@
+---
+id: temporal-cluster
+level: task
+title: "Temporal cluster: duration arithmetic, parsing, selection, DST"
+short_code: "GQLITE-T-0341"
+created_at: 2026-05-30T14:17:28.737710+00:00
+updated_at: 2026-05-30T14:17:28.737710+00:00
+parent: GQLITE-I-0049
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+exit_criteria_met: false
+initiative_id: tck-deep-item-conformance-temporal
+---
+
+# Temporal cluster: duration arithmetic, parsing, selection, DST
+
+## Parent Initiative
+[[GQLITE-I-0049]]
+
+## Objective
+
+Close the Temporal TCK cluster (~42 failing examples across Temporal1/2/3/5/7/8/10)
+with zero regressions. Temporal code lives in `src/backend/transform/transform_func_temporal.c`
+and the temporal UDFs/helpers in `src/backend/runtime/udf_helpers.c` (duration JSON
+builder, ISO parsing, epoch-ns conversions). Durations are stored as the JSON object
+`{"_iso8601": "...", "months": M, "days": D, "seconds": S, "nanosecondsOfSecond": N}`.
+
+## Sub-steps (decomposition, smallest-yield-first ordering TBD after analysis)
+
+1. **Duration arithmetic — Temporal8 (~12)**: add/subtract durations; add/subtract a
+   duration to/from date/time/localtime/datetime; multiply/divide a duration by a number.
+   Likely the biggest single win; concentrated in duration +/-/*//.
+2. **Duration between + DST + large — Temporal10 (~10)**: `duration.between` variants,
+   durations across daylight-saving boundaries, very large durations (seconds overflow).
+3. **Date/time selection — Temporal3 (~9)**: `date({...})` / `time({...})` /
+   `datetime({...})` selecting/combining component fields (truncation/selection forms).
+4. **Parsing edge cases — Temporal2 (~6)**: parse date/time/duration from string,
+   named time zones (`[Europe/Stockholm]`), fractional-second edge cases.
+5. **Construction / accessors / comparison — Temporal1/5/7 (~5)**: construct duration
+   (example 3), time-offset construction, datetime accessors, time & duration equality.
+
+## Method
+
+Per sub-step: enumerate failing examples + read each scenario's query and expected
+output; reproduce via `sqlite3 :memory:` (NOT ad-hoc chains — single queries through
+the harness for verification); find the common root cause; fix; rigorous full pass-set
+diff after each (zero regressions); unit 944/944; functional clean. Record findings here.
+
+## Acceptance Criteria
+- [ ] Temporal8 duration arithmetic examples pass
+- [ ] Temporal10 duration-between / DST / large examples pass
+- [ ] Temporal3 selection examples pass
+- [ ] Temporal2 parsing examples pass
+- [ ] Temporal1/5/7 construction/accessor/comparison examples pass
+- [ ] Zero TCK regressions across the whole cluster; unit 944/944; functional clean
+
+## Status Updates
+
+- 2026-05-30: Task created with sub-step breakdown from the failure inventory.
+  Baseline main = 3728 pass. Starting analysis with sub-step 1 (Temporal8 duration
+  arithmetic) — biggest concentrated win.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -548,3 +548,18 @@ pass-set diff: zero regressions, +3; unit 944/944; functional clean):
   error. keys() on a parameter/expression emits a single-eval subquery over
   json_each, using the value's `properties` object when present (node/rel) else
   its own keys (map). Fixes Graph3 [6], Graph4 [5], Map3 [2].
+
+## Coverage update (2026-05-30) — duration multiply/divide by a number (Temporal8 [7])
+
+`transform_expr_ops.c`, `udf_helpers.c`, `udf_register.c`. Verified via the TCK
+harness (3728 -> 3731, rigorous full pass-set diff: zero regressions, +3; unit
+944/944; functional clean):
+
+- **`duration * n` / `duration / n` now scale the duration component-wise**
+  instead of coercing the JSON to 0. New `_gql_dyn_mul` / `_gql_dyn_div` UDFs
+  (mirroring the ADD/SUB `_gql_dyn_*` dispatch) detect a Duration operand and
+  scale months/days/seconds/nanos by the factor, cascading each unit's
+  fractional remainder down via 1 month = 30.436875 days and 1 day = 86400 s
+  (components otherwise NOT normalized across each other); plain numerics keep
+  native int/float semantics. BINARY_OP_MUL/DIV route through the helpers unless
+  both operands are numeric literals. Fixes Temporal8 [7]. Part of GQLITE-T-0341.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -563,3 +563,21 @@ harness (3728 -> 3731, rigorous full pass-set diff: zero regressions, +3; unit
   (components otherwise NOT normalized across each other); plain numerics keep
   native int/float semantics. BINARY_OP_MUL/DIV route through the helpers unless
   both operands are numeric literals. Fixes Temporal8 [7]. Part of GQLITE-T-0341.
+
+## Coverage update (2026-05-30) — fractional duration construction + date arithmetic (Temporal8 [6]/[1])
+
+`udf_helpers.c`. Verified via the TCK harness (3731 -> 3742, rigorous full
+pass-set diff: zero regressions, +11; unit 944/944; functional clean):
+
+- **`duration({...})` with fractional components cascades correctly.** The
+  fractional-month→day carry used 30.0 days/month; corrected to 30.436875 (avg
+  Gregorian month), matching Cypher (Temporal8 [6] examples 3/6/7/8/9, Temporal1
+  [12], Temporal7 [6]).
+- **Durations no longer normalize sub-day time into days.** The composer's
+  day-overflow roll (seconds → days) was removed so `duration({hours:25})` stays
+  `PT25H` and a fractional duration keeps e.g. `PT67H` — consistent with
+  `emit_duration_json` used by duration addition.
+- **date + duration rolls the duration's whole-day time into the date.** Since
+  the duration value is no longer pre-normalized, `apply_duration_to_temporal`
+  now adds `time_ns / DAY_NS` whole days (trunc toward zero) to a pure-date input
+  and drops the sub-day remainder (Temporal8 [1] example 3). Part of GQLITE-T-0341.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -608,3 +608,19 @@ functional clean):
   the numeric offset, while `datetime()` retains it (+2, 3747->3749). The shared
   `_gql_time_compose` UDF gained a `drop_region` arg (1 for time, 0 for datetime).
   Part of GQLITE-T-0341.
+
+## Coverage update (2026-05-31) — Temporal cluster grind (T-0341), 3728 -> 3758 (+30)
+
+`udf_helpers.c`, `transform_func_temporal.c`, `udf_register.c`. Closed nearly the
+whole Temporal cluster across many rigorous-diff-verified commits: duration
+multiply/divide; fractional duration construction + date arithmetic;
+duration.inMonths/inDays tz normalization; date() quarter selection; time()
+region-drop; zero-offset -> Z; offset zero-seconds drop; date(datetime); ISO
+fractional-month cascade; UTC-instant temporal comparison; .timezone accessor;
+alternate ISO duration form. Unit 944/944, functional clean throughout.
+
+Remaining Temporal = the DST cluster only (12): Temporal10 [8] (across-DST-
+transition elapsed time), Temporal3 [10] / Temporal2 [6] (offset resolution on a
+DST-transition date). `named_tz_offset`'s month approximation is load-bearing
+(an accurate last-Sunday-rule swap regressed -29), so DST needs a careful,
+empirical, per-zone effort + across-transition interval math. Deferred.

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -581,3 +581,17 @@ pass-set diff: zero regressions, +11; unit 944/944; functional clean):
   the duration value is no longer pre-normalized, `apply_duration_to_temporal`
   now adds `time_ns / DAY_NS` whole days (trunc toward zero) to a pure-date input
   and drops the sub-day remainder (Temporal8 [1] example 3). Part of GQLITE-T-0341.
+
+## Coverage update (2026-05-30) — duration.inMonths/inDays tz normalization (Temporal10 [3]/[4])
+
+`udf_helpers.c`. Verified via the TCK harness (3742 -> 3744, rigorous full
+pass-set diff: zero regressions, +2; unit 944/944; functional clean):
+
+- **`duration.inMonths` / `duration.inDays` compare the time-of-day in UTC**
+  when both operands carry a tz offset, instead of the local clock face. A
+  tz-offset difference (e.g. `+0200` vs `+0100`) no longer spuriously drops a
+  whole month/day (Temporal10 [3] ex19 `P1Y`, [4] ex17 `P337D`). inDays was also
+  rewritten to count whole days from the calendar day difference minus a partial
+  trailing day (time-of-day comparison), using `days_from_civil` (unbounded)
+  instead of `timegm`. Part of GQLITE-T-0341. Remaining Temporal10: DST-aware
+  durations [8] and large-duration overflow [9]/[10] (deferred).

--- a/docs/testing/semantic-coverage-matrix.md
+++ b/docs/testing/semantic-coverage-matrix.md
@@ -595,3 +595,16 @@ pass-set diff: zero regressions, +2; unit 944/944; functional clean):
   trailing day (time-of-day comparison), using `days_from_civil` (unbounded)
   instead of `timegm`. Part of GQLITE-T-0341. Remaining Temporal10: DST-aware
   durations [8] and large-duration overflow [9]/[10] (deferred).
+
+## Coverage update (2026-05-30) — time() drops named-zone region; date() quarter selection (Temporal3)
+
+`udf_helpers.c`, `transform_func_temporal.c`, `udf_register.c`. Verified via the
+TCK harness (rigorous full pass-set diffs: zero regressions; unit 944/944;
+functional clean):
+
+- **`date({date: other, quarter: N})` preserves month-of-quarter + day** (+3,
+  3744->3747). Was resetting to the quarter's first month/day 1.
+- **`time()` / `localtime()` drop a named-zone `[Region]` suffix**, keeping only
+  the numeric offset, while `datetime()` retains it (+2, 3747->3749). The shared
+  `_gql_time_compose` UDF gained a `drop_region` arg (1 for time, 0 for datetime).
+  Part of GQLITE-T-0341.

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -1264,6 +1264,25 @@ void gql_order_key_func(
  * Values arrive as untyped SQLite cells; JSON entity/map/path shapes are told
  * apart by their distinctive keys (heuristic, sufficient for the value shapes
  * this engine emits). GQLITE-T-0340. */
+/* Normalize a numeric tz offset string: drop a zero seconds suffix, keep
+ * non-zero seconds (Temporal1 [13]: '+02:05:00' -> '+02:05', '+02:05:59' kept).
+ * Non-offset inputs (e.g. 'Z', a named zone) pass through unchanged. */
+void gql_fmt_offset_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+    if (argc != 1) { sqlite3_result_null(context); return; }
+    const char *tz = (const char*)sqlite3_value_text(argv[0]);
+    if (!tz) { sqlite3_result_null(context); return; }
+    int oh = 0, om = 0, os = 0;
+    if ((tz[0] == '+' || tz[0] == '-') &&
+        sscanf(tz + 1, "%d:%d:%d", &oh, &om, &os) >= 2) {
+        char buf[16];
+        if (os != 0) snprintf(buf, sizeof(buf), "%c%02d:%02d:%02d", tz[0], oh, om, os);
+        else         snprintf(buf, sizeof(buf), "%c%02d:%02d", tz[0], oh, om);
+        sqlite3_result_text(context, buf, -1, SQLITE_TRANSIENT);
+    } else {
+        sqlite3_result_text(context, tz, -1, SQLITE_TRANSIENT);
+    }
+}
+
 void gql_order_rank_func(
     sqlite3_context *context,
     int argc,

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2883,6 +2883,20 @@ void gql_duration_parse_iso_func(sqlite3_context *ctx, int argc, sqlite3_value *
     double hours = 0, minutes = 0, seconds = 0;
     bool in_time = false;
     const char *p = s + 1;
+    /* Alternate ISO form P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss] (Temporal2 [7] ex8).
+     * Detected by date-style dashes after 'P'; the unit-letter form below has
+     * none. */
+    {
+        int Y = 0, Mo = 0, D = 0, H = 0, Mi = 0; double S = 0;
+        int n = sscanf(p, "%d-%d-%dT%d:%d:%lf", &Y, &Mo, &D, &H, &Mi, &S);
+        if (n >= 3 && strchr(p, '-')) {
+            years = Y; months = Mo; days = D;
+            if (n >= 4) hours = H;
+            if (n >= 5) minutes = Mi;
+            if (n >= 6) seconds = S;
+            p = ""; /* skip the unit-letter loop below */
+        }
+    }
     while (*p) {
         if (*p == 'T') { in_time = true; p++; continue; }
         /* Parse a numeric value (with optional sign + fractional). */

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -20,6 +20,7 @@
 #include <regex.h>
 #include <time.h>
 #include <stdbool.h>
+#include <math.h>
 #include <stdint.h>
 
 #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
@@ -2333,6 +2334,96 @@ void gql_dyn_add_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
 }
 void gql_dyn_sub_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
     gql_dyn_addsub_func(ctx, argc, argv, -1);
+}
+
+/* Scale a Duration by a numeric factor (Temporal8 [7]). Cypher multiplies each
+ * component (months, days, seconds, nanos) by the factor and cascades the
+ * fractional remainder of each larger unit down into the next smaller one, using
+ * the duration-arithmetic conversions 1 month = 30.436875 days and 1 day = 86400
+ * seconds. Components are NOT otherwise normalized across each other. */
+static void scale_duration(sqlite3_context *ctx, const char *dur, double factor) {
+    double months_f = (double)dur_field_ll(dur, "months") * factor;
+    double days_f   = (double)dur_field_ll(dur, "days") * factor;
+    double total_ns_base = ((double)dur_field_ll(dur, "seconds") * 1e9
+                            + (double)dur_field_ll(dur, "nanosecondsOfSecond")) * factor;
+
+    /* trunc toward zero keeps the signed fraction so negatives cascade too. */
+    double months_int = trunc(months_f);
+    double month_frac = months_f - months_int;
+    days_f += month_frac * 30.436875;        /* avg Gregorian month in days */
+
+    double days_int = trunc(days_f);
+    double day_frac = days_f - days_int;
+    double total_ns = total_ns_base + day_frac * 86400.0 * 1e9;
+
+    /* Cypher truncates the final nanosecond toward zero. But the carries above
+     * accumulate floating-point noise (~0.02 ULP at this magnitude), so an
+     * exact-integer result can read as x.9999. Snap to the nearest integer when
+     * within a small tolerance (absorbs the noise), otherwise truncate toward
+     * zero (so a genuine half like *0.5 of an odd nanosecond drops, not rounds). */
+    double rounded = round(total_ns);
+    long long ns_ll = (fabs(total_ns - rounded) < 0.05)
+                          ? (long long)rounded
+                          : (long long)trunc(total_ns);
+    emit_duration_json(ctx, (long long)months_int, (long long)days_int, ns_ll);
+}
+
+/* `_gql_dyn_mul` / `_gql_dyn_div`: numeric * / / that also scales a Duration
+ * operand (Temporal8 [7]). `op` is '*' or '/'. */
+static void gql_dyn_muldiv_func(sqlite3_context *ctx, int argc, sqlite3_value **argv, char op) {
+    if (argc != 2) { sqlite3_result_null(ctx); return; }
+    int t0 = sqlite3_value_type(argv[0]);
+    int t1 = sqlite3_value_type(argv[1]);
+    if (t0 == SQLITE_NULL || t1 == SQLITE_NULL) { sqlite3_result_null(ctx); return; }
+
+    const char *l_dur = NULL, *r_dur = NULL;
+    bool l_is_dur = is_duration_value(argv[0], &l_dur);
+    bool r_is_dur = is_duration_value(argv[1], &r_dur);
+
+    if (l_is_dur && !r_is_dur) {
+        /* duration * num  or  duration / num */
+        double n = sqlite3_value_double(argv[1]);
+        if (op == '/') {
+            if (n == 0.0) { sqlite3_result_null(ctx); return; }
+            n = 1.0 / n;
+        }
+        scale_duration(ctx, l_dur, n);
+        return;
+    }
+    if (r_is_dur && !l_is_dur && op == '*') {
+        /* num * duration (commutes for * only) */
+        scale_duration(ctx, r_dur, sqlite3_value_double(argv[0]));
+        return;
+    }
+    if (l_is_dur || r_is_dur) {
+        /* num / duration, duration * duration, etc. — undefined. */
+        sqlite3_result_null(ctx);
+        return;
+    }
+
+    /* Plain numeric: preserve SQLite-native int/float semantics. */
+    if (op == '*') {
+        if (t0 == SQLITE_INTEGER && t1 == SQLITE_INTEGER) {
+            sqlite3_result_int64(ctx, sqlite3_value_int64(argv[0]) * sqlite3_value_int64(argv[1]));
+        } else {
+            sqlite3_result_double(ctx, sqlite3_value_double(argv[0]) * sqlite3_value_double(argv[1]));
+        }
+    } else { /* '/' — Cypher integer division truncates toward zero. */
+        if (t0 == SQLITE_INTEGER && t1 == SQLITE_INTEGER) {
+            long long b = sqlite3_value_int64(argv[1]);
+            if (b == 0) { sqlite3_result_null(ctx); return; }
+            sqlite3_result_int64(ctx, sqlite3_value_int64(argv[0]) / b);
+        } else {
+            sqlite3_result_double(ctx, sqlite3_value_double(argv[0]) / sqlite3_value_double(argv[1]));
+        }
+    }
+}
+
+void gql_dyn_mul_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    gql_dyn_muldiv_func(ctx, argc, argv, '*');
+}
+void gql_dyn_div_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    gql_dyn_muldiv_func(ctx, argc, argv, '/');
 }
 
 /* Compose a YYYY-MM-DD date string from a map's named components. Used by

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2545,11 +2545,28 @@ void gql_date_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         snprintf(buf, sizeof(buf), "%04d-%02d-%02d", oy, omm, odd);
     } else if (sqlite3_value_type(argv[6]) != SQLITE_NULL) {
         int q = sqlite3_value_int(argv[6]);
-        int doq = (sqlite3_value_type(argv[7]) != SQLITE_NULL) ? sqlite3_value_int(argv[7]) : 1;
-        int month = (q - 1) * 3 + 1;
-        long start_days = days_from_civil(y, month, 1);
-        civil_from_days(start_days + (doq - 1), &oy, &omm, &odd);
-        snprintf(buf, sizeof(buf), "%04d-%02d-%02d", oy, omm, odd);
+        if (sqlite3_value_type(argv[7]) != SQLITE_NULL) {
+            /* dayOfQuarter is absolute within the quarter. */
+            int doq = sqlite3_value_int(argv[7]);
+            int month = (q - 1) * 3 + 1;
+            long start_days = days_from_civil(y, month, 1);
+            civil_from_days(start_days + (doq - 1), &oy, &omm, &odd);
+            snprintf(buf, sizeof(buf), "%04d-%02d-%02d", oy, omm, odd);
+        } else {
+            /* Only `quarter` is selected — preserve the month-within-quarter and
+             * day from the base value (or month/day scalar overrides). E.g.
+             * quarter 3 over 1984-11-11 (Q4 month-2, day 11) -> 1984-08-11.
+             * (Temporal3 [1] quarter examples.) */
+            int src_mo = (sqlite3_value_type(argv[1]) != SQLITE_NULL)
+                             ? sqlite3_value_int(argv[1]) : mo;
+            int month_in_q = ((src_mo - 1) % 3 + 3) % 3 + 1;
+            int new_month = (q - 1) * 3 + month_in_q;
+            int day = (sqlite3_value_type(argv[2]) != SQLITE_NULL)
+                          ? sqlite3_value_int(argv[2]) : d;
+            int dim = days_in_month_c(y, new_month);
+            if (day > dim) day = dim;
+            snprintf(buf, sizeof(buf), "%04d-%02d-%02d", y, new_month, day);
+        }
     } else {
         if (sqlite3_value_type(argv[1]) != SQLITE_NULL) mo = sqlite3_value_int(argv[1]);
         if (sqlite3_value_type(argv[2]) != SQLITE_NULL) d = sqlite3_value_int(argv[2]);

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -3069,6 +3069,18 @@ void gql_temporal_field_func(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if (p.has_tz) {
         if (strcmp(field, "offsetMinutes") == 0) { sqlite3_result_int(ctx, p.tz_offset_min); return; }
         if (strcmp(field, "offsetSeconds") == 0) { sqlite3_result_int(ctx, p.tz_offset_min * 60); return; }
+        if (strcmp(field, "timezone") == 0) {
+            /* `.timezone` returns the named zone when present (e.g.
+             * 'Europe/Stockholm'), otherwise the numeric offset (Temporal5 [6]). */
+            const char *lb = s ? strchr(s, '[') : NULL;
+            if (lb) {
+                const char *rb = strchr(lb, ']');
+                int zlen = rb ? (int)(rb - lb - 1) : (int)strlen(lb + 1);
+                sqlite3_result_text(ctx, lb + 1, zlen, SQLITE_TRANSIENT);
+                return;
+            }
+            /* fall through to offset form below */
+        }
         if (strcmp(field, "offset") == 0 || strcmp(field, "timezone") == 0) {
             char buf[16];
             int oh = p.tz_offset_min / 60;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -3080,6 +3080,18 @@ void gql_normalize_date_func(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if (argc != 1) { sqlite3_result_null(ctx); return; }
     const char *s = (const char*)sqlite3_value_text(argv[0]);
     if (!s) { sqlite3_result_null(ctx); return; }
+    /* date(datetime/localdatetime): keep only the date portion before the 'T'
+     * so '1984-11-11T12:31:14' yields '1984-11-11' rather than failing the
+     * length checks below (Temporal3 [1] ex8/15). */
+    char datebuf[16];
+    const char *Tpos = strchr(s, 'T');
+    if (Tpos) {
+        size_t dlen = (size_t)(Tpos - s);
+        if (dlen >= sizeof(datebuf)) dlen = sizeof(datebuf) - 1;
+        memcpy(datebuf, s, dlen);
+        datebuf[dlen] = 0;
+        s = datebuf;
+    }
     int len = (int)strlen(s);
     bool has_W = strchr(s, 'W') != NULL;
     bool has_dash = strchr(s, '-') != NULL;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2583,7 +2583,11 @@ void gql_date_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
  *   8 base_time, 9 base_datetime, 10 base_localdatetime, 11 base_localtime
  */
 void gql_time_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
-    if (argc != 12) { sqlite3_result_null(ctx); return; }
+    if (argc != 13) { sqlite3_result_null(ctx); return; }
+    /* drop_region: a Cypher time/localtime value never carries a named zone —
+     * keep only the numeric offset. datetime() passes 0 to retain it. */
+    int drop_region = (sqlite3_value_type(argv[12]) != SQLITE_NULL)
+                          ? sqlite3_value_int(argv[12]) : 0;
     int h = 0, mi = 0, sec = 0;
     int64_t ns = 0;
     bool inherit_subsec = false;
@@ -2702,12 +2706,23 @@ void gql_time_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
                  * a summer date (most TCK tests with named zones use one).
                  * For datetime() the outer SQL replaces this when needed. */
                 const char *off = named_tz_offset(tz, 2000, 7, 15);
-                p += snprintf(p, sizeof(buf) - (p - buf), "%s[%s]", off, tz);
+                if (drop_region)
+                    p += snprintf(p, sizeof(buf) - (p - buf), "%s", off);
+                else
+                    p += snprintf(p, sizeof(buf) - (p - buf), "%s[%s]", off, tz);
             } else if (tz) {
                 p += snprintf(p, sizeof(buf) - (p - buf), "%s", tz);
             }
         } else if (base_tz) {
-            p += snprintf(p, sizeof(buf) - (p - buf), "%s", base_tz);
+            /* Inherited from a base value. A time value drops any [Region]
+             * suffix, keeping only the offset (Temporal3 [3]). */
+            if (drop_region) {
+                const char *br = strchr(base_tz, '[');
+                if (br) p += snprintf(p, sizeof(buf) - (p - buf), "%.*s", (int)(br - base_tz), base_tz);
+                else    p += snprintf(p, sizeof(buf) - (p - buf), "%s", base_tz);
+            } else {
+                p += snprintf(p, sizeof(buf) - (p - buf), "%s", base_tz);
+            }
         } else {
             *p++ = 'Z'; *p = 0;
         }

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2115,6 +2115,14 @@ static void apply_duration_to_temporal(sqlite3_context *ctx, const char *tempora
             residue_ns = time_ns - extra_days * DAY_NS;
             if (residue_ns < 0) { residue_ns += DAY_NS; extra_days -= 1; }
             base_days += extra_days;
+        } else {
+            /* Pure date + duration: the duration's sub-day time still
+             * contributes its WHOLE days (truncated toward zero); the sub-day
+             * remainder is dropped since a date has no time-of-day. The
+             * duration value itself is not normalized — only this date
+             * arithmetic rolls the hours into days. (Temporal8 [1] example 3.) */
+            long long DAY_NS = 86400LL * 1000000000LL;
+            base_days += add_total_ns / DAY_NS;
         }
         int oy, om, od;
         civil_from_days(base_days, &oy, &om, &od);
@@ -2730,7 +2738,10 @@ void gql_duration_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **a
         double total_months_d = years * 12.0 + months;
         total_months = (long long)total_months_d;
         double frac_months = total_months_d - total_months;
-        double total_days_d = weeks * 7.0 + days + frac_months * 30.0;
+        /* Fractional months convert to days at the average Gregorian month
+         * (365.2425/12 = 30.436875 days), matching Cypher duration arithmetic
+         * (Temporal8 [6]). */
+        double total_days_d = weeks * 7.0 + days + frac_months * 30.436875;
         total_days = (long long)total_days_d;
         double frac_days = total_days_d - total_days;
         double total_seconds_d = frac_days * 86400.0 + hours * 3600.0
@@ -2742,14 +2753,12 @@ void gql_duration_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **a
         total_ns = total_secs * 1000000000LL + total_ns_from_secs + extra_ns;
     }
 
-    /* Move full-day overflow from total_ns into total_days using
-     * trunc-toward-zero division — preserves the sign of total_ns so
-     * inputs like {days:1, milliseconds:-1} keep the day and time signs
-     * separate ('P1DT-0.001S' rather than 'PT23H59M59.999S'). */
-    long long DAY_NS = 86400LL * 1000000000LL;
-    long long extra_days = total_ns / DAY_NS;
-    long long residue_ns = total_ns - extra_days * DAY_NS;
-    total_days += extra_days;
+    /* Cypher durations do NOT normalize sub-day time into the days field — the
+     * seconds component keeps hours even past 24 (e.g. `PT67H`, Temporal8 [6]).
+     * Only weeks→days and the fractional month/day carries above feed `days`;
+     * the time residue stays in `total_ns`. (`emit_duration_json`, used by
+     * duration addition, follows the same rule — keeping the two consistent.) */
+    long long residue_ns = total_ns;
 
     char iso[160];
     format_iso_duration((int)total_months, (int)total_days, residue_ns, iso, sizeof(iso));

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -382,6 +382,23 @@ static int gql_cmp_json_vals(sqlite3 *db,
  *
  *   Called by transform_binary_operation's LT/GT/LTE/GTE path —
  *   each operand is transformed exactly once. */
+static int64_t parse_temporal_ns(const char *s);  /* defined below */
+
+/* Heuristic: does the text look like a Cypher temporal value (time 'HH:MM…' or
+ * date/datetime 'YYYY-MM-DD…')? Used so ordered comparison of two temporals
+ * uses their UTC instant rather than a lexical compare (Temporal7 [3]). */
+static bool looks_temporal(const char *s) {
+    if (!s) return false;
+    size_t n = strlen(s);
+    if (n >= 5 && s[0] >= '0' && s[0] <= '9' && s[1] >= '0' && s[1] <= '9' &&
+        s[2] == ':' && s[3] >= '0' && s[3] <= '9' && s[4] >= '0' && s[4] <= '9')
+        return true;  /* time HH:MM… */
+    if (n >= 10 && s[4] == '-' && s[7] == '-' &&
+        s[0] >= '0' && s[0] <= '9' && s[1] >= '0' && s[1] <= '9')
+        return true;  /* date / datetime YYYY-MM-DD… */
+    return false;
+}
+
 void gql_order_cmp_func(
     sqlite3_context *context, int argc, sqlite3_value **argv) {
     if (argc != 3) { sqlite3_result_null(context); return; }
@@ -456,7 +473,14 @@ void gql_order_cmp_func(
         const char *a = (const char *)sqlite3_value_text(argv[0]);
         const char *b = (const char *)sqlite3_value_text(argv[1]);
         if (!a || !b) { sqlite3_result_null(context); return; }
-        cmp = strcmp(a, b);
+        if (looks_temporal(a) && looks_temporal(b)) {
+            /* Compare two temporal values by UTC instant, not lexically, so a
+             * tz offset is honored (Temporal7 [3]: 10:00+01:00 < 09:35+00:00). */
+            int64_t na = parse_temporal_ns(a), nb = parse_temporal_ns(b);
+            cmp = (na < nb) ? -1 : (na > nb) ? 1 : 0;
+        } else {
+            cmp = strcmp(a, b);
+        }
         if (cmp < 0) cmp = -1;
         else if (cmp > 0) cmp = 1;
     } else {

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -1659,6 +1659,8 @@ static int days_in_month_c(int year, int month) {
  * is missing a date or time component, the result borrows zero for that
  * component. Components share sign per-section (date and time may have
  * opposite signs to match TCK examples like 'P-27DT-21H-40M-32.142S'). */
+static long days_from_civil(int y, int m, int d);  /* defined below */
+
 static int64_t time_ns_of(const tparts *p) {
     if (!p->has_time) return 0;
     int64_t NS = 1000000000LL;
@@ -1811,12 +1813,21 @@ void gql_duration_in_days_func(sqlite3_context *ctx, int argc, sqlite3_value **a
     if (!parse_temporal_parts(sa, &a) || !parse_temporal_parts(sb, &b)) { sqlite3_result_null(ctx); return; }
     int64_t days = 0;
     if (a.has_date && b.has_date) {
-        struct tm ta, tb;
-        memset(&ta, 0, sizeof(ta)); memset(&tb, 0, sizeof(tb));
-        ta.tm_year = a.y - 1900; ta.tm_mon = a.mo - 1; ta.tm_mday = a.d;
-        tb.tm_year = b.y - 1900; tb.tm_mon = b.mo - 1; tb.tm_mday = b.d;
-        time_t epa = timegm(&ta), epb = timegm(&tb);
-        days = (epb - epa) / 86400;
+        /* Whole days in the elapsed period — the calendar day difference,
+         * reduced by one when the later instant's time-of-day falls short of
+         * the earlier one (so a partial trailing day isn't counted). Compare in
+         * UTC when both sides carry a tz offset (Temporal10 [4] example 17). */
+        int cmp = compare_temporal(&a, &b);
+        bool forward = (cmp <= 0);
+        const tparts *lo = forward ? &a : &b;
+        const tparts *hi = forward ? &b : &a;
+        int64_t dd = days_from_civil(hi->y, hi->mo, hi->d)
+                   - days_from_civil(lo->y, lo->mo, lo->d);
+        int64_t lo_t, hi_t;
+        if (lo->has_tz && hi->has_tz) { lo_t = time_ns_of_utc(lo); hi_t = time_ns_of_utc(hi); }
+        else { lo_t = time_ns_of(lo); hi_t = time_ns_of(hi); }
+        if (hi_t < lo_t) dd -= 1;
+        days = forward ? dd : -dd;
     }
     char iso[64];
     if (days == 0) snprintf(iso, sizeof(iso), "PT0S");
@@ -1844,8 +1855,12 @@ void gql_duration_in_months_func(sqlite3_context *ctx, int argc, sqlite3_value *
         const tparts *hi = forward ? &b : &a;
         int y = hi->y - lo->y, m = hi->mo - lo->mo, dd = hi->d - lo->d;
         /* When days equal, also account for time-of-day: a full month is
-         * only reached when hi.time >= lo.time. */
-        int64_t lo_t = time_ns_of(lo), hi_t = time_ns_of(hi);
+         * only reached when hi.time >= lo.time. Compare in UTC when both sides
+         * carry a tz offset so a tz difference doesn't spuriously drop a month
+         * (Temporal10 [3] example 19). */
+        int64_t lo_t, hi_t;
+        if (lo->has_tz && hi->has_tz) { lo_t = time_ns_of_utc(lo); hi_t = time_ns_of_utc(hi); }
+        else { lo_t = time_ns_of(lo); hi_t = time_ns_of(hi); }
         if (dd < 0 || (dd == 0 && hi_t < lo_t)) m -= 1;
         if (m < 0) { m += 12; y -= 1; }
         total_months = y * 12 + m;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -2893,7 +2893,9 @@ void gql_duration_parse_iso_func(sqlite3_context *ctx, int argc, sqlite3_value *
     double total_months_d = years * 12.0 + months;
     int total_months = (int)total_months_d;
     double frac_months = total_months_d - total_months;
-    double total_days_d = weeks * 7.0 + days + frac_months * 30.0;
+    /* Fractional months cascade to days at the average Gregorian month
+     * (30.436875), matching Cypher (Temporal2 [7] 'P0.75M'). */
+    double total_days_d = weeks * 7.0 + days + frac_months * 30.436875;
     long long total_days = (long long)total_days_d;
     double frac_days = total_days_d - total_days;
     double total_seconds_d = frac_days * 86400.0 + hours * 3600.0 + minutes * 60.0 + seconds;

--- a/src/backend/runtime/udf_helpers.c
+++ b/src/backend/runtime/udf_helpers.c
@@ -1435,7 +1435,9 @@ void gql_extract_tz_func(
     const char *start;
     if (t) {
         start = t + 1;
-    } else if (strlen(s) >= 8 && s[2] == ':') {
+    } else if (strlen(s) >= 5 && s[2] == ':') {
+        /* Time-only 'HH:MM[...]' — a 'Z' or offset can follow as early as
+         * position 5 (e.g. '21:40Z'), so require only HH:MM, not HH:MM:SS. */
         start = s;
     } else {
         sqlite3_result_text(context, "", 0, SQLITE_TRANSIENT); return;
@@ -3197,8 +3199,12 @@ void gql_normalize_time_func(sqlite3_context *ctx, int argc, sqlite3_value **arg
             }
             /* A `time` value carries only the numeric offset — the named-zone
              * bracket (e.g. [Europe/Stockholm], already resolved to the offset)
-             * is dropped (only datetime keeps the zone name). Temporal3 [3]. */
-            snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d", tz_main[0], oh, om);
+             * is dropped (only datetime keeps the zone name). Temporal3 [3].
+             * A zero offset renders as `Z`, not `±00:00` (Temporal2 [3]). */
+            if (oh == 0 && om == 0)
+                snprintf(tz_out, sizeof(tz_out), "Z");
+            else
+                snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d", tz_main[0], oh, om);
         }
     }
 
@@ -3372,7 +3378,12 @@ void gql_normalize_datetime_func(sqlite3_context *ctx, int argc, sqlite3_value *
                 if (strchr(tz_main + 1, ':')) sscanf(tz_main + 1, "%d:%d", &oh, &om);
                 else if (strlen(tz_main + 1) >= 4) sscanf(tz_main + 1, "%2d%2d", &oh, &om);
                 else sscanf(tz_main + 1, "%d", &oh);
-                snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d%s", tz_main[0], oh, om, bracket ? bracket : "");
+                /* A zero numeric offset with no named zone renders as `Z`
+                 * (Temporal2 [5]); a named zone keeps the explicit offset. */
+                if (oh == 0 && om == 0 && !bracket)
+                    snprintf(tz_out, sizeof(tz_out), "Z");
+                else
+                    snprintf(tz_out, sizeof(tz_out), "%c%02d:%02d%s", tz_main[0], oh, om, bracket ? bracket : "");
             } else if (*tz_start == '[') snprintf(tz_out, sizeof(tz_out), "%s", tz_start);
         }
 

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -88,6 +88,12 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
                          gql_order_rank_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
 
+  /* Normalize a numeric tz offset (drop a zero seconds suffix). */
+  rc = sqlite3_create_function(db, "_gql_fmt_offset", 1,
+                         SQLITE_UTF8 | SQLITE_DETERMINISTIC, 0,
+                         gql_fmt_offset_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
+
   /* labels()/type() over a statically-Any argument: return the labels/type for
    * a node/relationship value, null for null, else raise a TypeError. */
   rc = sqlite3_create_function(db, "_gql_labels", 1,

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -219,7 +219,7 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
   rc = sqlite3_create_function(db, "_gql_date_compose", 10, SQLITE_UTF8, 0,
                          gql_date_compose_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
-  rc = sqlite3_create_function(db, "_gql_time_compose", 12, SQLITE_UTF8, 0,
+  rc = sqlite3_create_function(db, "_gql_time_compose", 13, SQLITE_UTF8, 0,
                          gql_time_compose_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
 

--- a/src/backend/runtime/udf_register.c
+++ b/src/backend/runtime/udf_register.c
@@ -187,6 +187,12 @@ int graphqlite_register_helper_udfs(sqlite3 *db)
   rc = sqlite3_create_function(db, "_gql_dyn_sub", 2, SQLITE_UTF8, 0,
                          gql_dyn_sub_func, 0, 0);
   if (rc != SQLITE_OK) return rc;
+  rc = sqlite3_create_function(db, "_gql_dyn_mul", 2, SQLITE_UTF8, 0,
+                         gql_dyn_mul_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
+  rc = sqlite3_create_function(db, "_gql_dyn_div", 2, SQLITE_UTF8, 0,
+                         gql_dyn_div_func, 0, 0);
+  if (rc != SQLITE_OK) return rc;
 
   rc = sqlite3_create_function(db, "_gql_duration_from_total_ns", 1, SQLITE_UTF8, 0,
                          gql_duration_from_total_ns_func, 0, 0);

--- a/src/backend/transform/transform_expr_ops.c
+++ b/src/backend/transform/transform_expr_ops.c
@@ -537,6 +537,30 @@ int transform_binary_operation(cypher_transform_context *ctx, cypher_binary_op *
         }
     }
 
+    /* MUL/DIV: route through `_gql_dyn_mul` / `_gql_dyn_div` so a Duration
+     * operand is scaled component-wise (Temporal8 [7]); plain numerics keep
+     * native int/float semantics inside the helper. Skip the helper when both
+     * operands are numeric literals (no duration possible) to avoid overhead. */
+    if (binary_op->op_type == BINARY_OP_MUL || binary_op->op_type == BINARY_OP_DIV) {
+        bool both_num_lit = false;
+        if (binary_op->left->type == AST_NODE_LITERAL && binary_op->right->type == AST_NODE_LITERAL) {
+            cypher_literal *ll = (cypher_literal *)binary_op->left;
+            cypher_literal *rl = (cypher_literal *)binary_op->right;
+            bool l_num = ll->literal_type == LITERAL_INTEGER || ll->literal_type == LITERAL_DECIMAL;
+            bool r_num = rl->literal_type == LITERAL_INTEGER || rl->literal_type == LITERAL_DECIMAL;
+            both_num_lit = l_num && r_num;
+        }
+        if (!both_num_lit) {
+            append_sql(ctx, binary_op->op_type == BINARY_OP_MUL ? "_gql_dyn_mul(" : "_gql_dyn_div(");
+            if (transform_expression(ctx, binary_op->left) < 0) return -1;
+            append_sql(ctx, ", ");
+            if (transform_expression(ctx, binary_op->right) < 0) return -1;
+            append_sql(ctx, "))");
+            ctx->in_comparison = was_in_comparison;
+            return 0;
+        }
+    }
+
     /* Transform left expression */
     CYPHER_DEBUG("Transforming left operand");
     if (transform_expression(ctx, binary_op->left) < 0) {

--- a/src/backend/transform/transform_func_temporal.c
+++ b/src/backend/transform/transform_func_temporal.c
@@ -243,7 +243,9 @@ int transform_time_function(cypher_transform_context *ctx, cypher_function_call 
                     if (transform_expression(ctx, arg) < 0) return -1;
                     append_sql(ctx, "), '$.%s')", base_keys[i]);
                 }
-                append_sql(ctx, ")");
+                /* drop_region=1: a Cypher time/localtime never carries a named
+                 * zone — keep only the offset (Temporal3 [3]). */
+                append_sql(ctx, ", 1)");
                 return 0;
             }
             const char *fmt_in_sql;
@@ -417,7 +419,8 @@ int transform_datetime_function(cypher_transform_context *ctx, cypher_function_c
                     if (transform_expression(ctx, arg) < 0) return -1;
                     append_sql(ctx, "), '$.%s')", base_keys[i]);
                 }
-                append_sql(ctx, "))");
+                /* drop_region=0: datetime keeps the named-zone suffix. */
+                append_sql(ctx, ", 0))");
                 return 0;
             }
 

--- a/src/backend/transform/transform_func_temporal.c
+++ b/src/backend/transform/transform_func_temporal.c
@@ -290,9 +290,9 @@ int transform_time_function(cypher_transform_context *ctx, cypher_function_call 
                                  "WHEN substr(json_extract(json(");
                 if (transform_expression(ctx, arg) < 0) return -1;
                 append_sql(ctx, "), '$.timezone'),1,1) IN ('+','-') "
-                                 "THEN json_extract(json(");
+                                 "THEN _gql_fmt_offset(json_extract(json(");
                 if (transform_expression(ctx, arg) < 0) return -1;
-                append_sql(ctx, "), '$.timezone') "
+                append_sql(ctx, "), '$.timezone')) "
                                  "ELSE '[' || json_extract(json(");
                 if (transform_expression(ctx, arg) < 0) return -1;
                 append_sql(ctx, "), '$.timezone') || ']' END)");

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -52,6 +52,8 @@ void gql_duration_calendar_func(sqlite3_context *ctx, int argc, sqlite3_value **
 void gql_tz_offset_for_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_dyn_add_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_dyn_sub_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_dyn_mul_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_dyn_div_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 
 /* Temporal value construction + parsing + reflection */
 void gql_date_compose_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);

--- a/src/include/runtime/udf_helpers.h
+++ b/src/include/runtime/udf_helpers.h
@@ -37,6 +37,7 @@ void gql_order_cmp_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 /* Order key + namespace/timezone extractors */
 void gql_order_key_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_order_rank_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+void gql_fmt_offset_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_labels_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_type_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);
 void gql_extract_ns_func(sqlite3_context *ctx, int argc, sqlite3_value **argv);


### PR DESCRIPTION
Closes the entire **non-DST** Temporal TCK cluster — **3728 → 3758 (+30)**, zero regressions. Each fix verified with a rigorous full pass-set diff; unit 944/944; functional clean throughout. Part of initiative GQLITE-I-0049, task GQLITE-T-0341.

## Fixes (all duration/date/time semantics)
- **Duration arithmetic:** `* n` / `/ n` component scaling (+3); fractional construction + date arithmetic with 1 month = 30.436875 days (+11); ISO fractional-month cascade (+1); alternate ISO form `P<date>T<time>` (+1).
- **duration.between:** `inMonths`/`inDays` tz normalization (UTC instant) (+2).
- **Selection:** `date()` quarter preserves month-of-quarter + day (+3); `time()` drops named-zone `[Region]` (+2).
- **Formatting:** zero offset → `Z` (+2); offset zero-seconds drop `+02:05:00`→`+02:05` (+1); `date(datetime)` extracts the date (+2).
- **Comparison/accessors:** temporal `<`/`>` compares UTC instants (+1); `.timezone` accessor returns the zone name (+1).

**Temporal8 went 27/27.** Of the original ~42 Temporal failures, only the 12 DST scenarios remain.

## DST is deliberately out of scope (documented in GQLITE-T-0341)
The remaining 12 (Temporal10 [8], Temporal3 [10], Temporal2 [6]) require an embedded **IANA timezone database**, not a rule-based approximation:
- The TCK encodes historical data — e.g. `1818-07-21 Stockholm = +00:53:28` (Local Mean Time), `1984-10-11 Stockholm = +01:00` (pre-1996 EU DST ended the last Sunday of *September*).
- A modern last-Sunday rule regressed −52 examples; the existing coarse approximation is load-bearing.
- Temporal10 [8] also needs across-transition elapsed time (24 wall-clock hrs = 25 real hrs on the fall-back day).

Tracked as a separate large, data-heavy follow-up.