### PR TITLE
transform_match: null statement after label for C17 portability

### DIFF
--- a/src/backend/transform/transform_match.c
+++ b/src/backend/transform/transform_match.c
@@ -2003,7 +2003,9 @@ static int generate_relationship_match(cypher_transform_context *ctx, cypher_rel
             sql_join(ctx->unified_builder, SQL_JOIN_CROSS, get_graph_table(ctx, "nodes"), target_alias, NULL);
         }
 
-skip_target_node_join:
+skip_target_node_join: ;  /* null statement: a label may not precede a
+        * declaration in C17 and earlier — Apple clang rejects
+        * `label: char x[..]` outright (the release macos build). */
         /* Add label constraints for target node if specified.
          *
          * I-0047 P3: for OPTIONAL + varlen with a DEFERRED target


### PR DESCRIPTION
## Problem
The v0.6.0 release build failed on the `macos-14` runner with:
```
src/backend/transform/transform_match.c:2016: error: expected expression
... use of undeclared identifier 'deferred_tgt_label_cond'
```
`skip_target_node_join:` is a label immediately followed by a *declaration* (`char deferred_tgt_label_cond[512]`). In C17 and earlier a label may only precede a **statement**, not a declaration. Apple clang on macos-14 (default ~C17) rejects it; gcc and newer clang (C23 default) accept it as an extension — which is why PR CI (`full-build-unix macos-latest`) and local builds passed but the release runner did not.

No partial release occurred: the build failure skipped `build-wheels`, `publish-python`, `publish-rust`, and `create-release` — nothing was published to PyPI, crates.io, or GitHub releases.

## Fix
Add a null statement (`;`) after the label. Verified:
- `clang -std=c17 -fsyntax-only` passes on **all** backend `.c` files (scanned every goto label; this was the only label-before-declaration).
- Extension builds; runtime behavior unchanged.

## Why not switch the release runner to macos-latest?
That would mask non-conformant C that other strict toolchains would also reject, and swap a pinned runner for a moving target in arch-specific release artifacts. Fixing the code is the portable fix.

After merge: re-tag v0.6.0 to re-run the release.